### PR TITLE
OK-634: Use docker-compose instead of TestContainers to run Elasticsearch for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,23 @@ jobs:
         with:
           timezoneLinux: "Europe/Helsinki"
 
-      - name: Build with Maven
+      - name: Set up build prerequisites
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          cd postgresql/docker
-          docker build --tag koutaexternal-postgres .
-          cd -
+          (cd postgresql/docker && docker build --tag koutaexternal-postgres .)
+          sudo apt install docker-compose
+          docker-compose up -d kouta-elastic
+          docker-compose up elasticdump-loader
+
+      - name: Build with Maven
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
           mvn clean package -B
 
       - uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -50,7 +50,21 @@ Esimerkiksi `mvn test -Dsuites="fi.oph.kouta.external.integration.HakukohdeSpec"
 
 Koska Elasticsearch-datadumpin lataaminen kestää jonkin aikaa, luku-rajapintojen testejä toteuttaessa kannattaa ajaa testejä valmiiksi käynnistetyllä Elasticsearchilla.
 Katso ohjeet Elasticsearch-kontin käynnistämiseen [kouta-indeksoijan README:sta](https://github.com/Opetushallitus/kouta-indeksoija/#elasticsearch-kontin-käynnistys). 
-Huom! Jos käytät linuxia, vaihda komennon parametri `-p 127.0.0.1:9200:9200` -> `-p 9200:9200`. Muuten elasticdump ei saa yhteyttä elasticsearchiin. 
+
+Voit vaihtoehtoisesti käyttää valmista docker-compose-sääntöä (ks. [./docker-compose.yml]) Elasticsearchin ajamiseen:
+```
+$ docker-compose up -d kouta-elastic
+```
+
+Ja voit ladata tiedot etukäteen komennolla:
+```
+$ docker-compose up elasticdump-loader
+```
+
+Jos saat virheilmoituksen "Elasticsearch exited unexpectedly." on kyse todennäköisesti muistin loppumisesta.  Vapauta oman koneesi muistia (tai varaa Elastic-kontille lisää muistia) ja yritä uudelleen.
+
+Huom! Jos käytät linuxia ja kouta-indeksoijan ohjeita, vaihda komennon parametri `-p 127.0.0.1:9200:9200` -> `-p 9200:9200`. Muuten elasticdump ei saa yhteyttä elasticsearchiin.
+
 Aseta sitten muuttuja `useTestContainersElastic = false` täällä: https://github.com/Opetushallitus/kouta-external/blob/master/src/test/scala/fi/oph/kouta/external/TempElastic.scala#L9.
 Nyt voit ajaa testejä ilman jatkuvaa Elasticsearchin uudelleenkäynnistelyä ja dumppien latailua. Muista palauttaa `useTestContainersElastic = true`, kun olet valmis.
 

--- a/README.md
+++ b/README.md
@@ -38,35 +38,43 @@ Lokaalin ajon asetuksia voi muuttaa muokkaamalla '/src/test/resources/dev-vars.y
 
 ### 3.2. Testien ajaminen
 
-Testejä varten täytyy Docker daemon olla käynnissä. Yksittäisen testisuiten tai testin voi ajaa IntelliJ IDEA:ssa halutun testiluokan tai funktion päältä, run -> scalaTest.
-Testien ajaminen käynnistää docker-kontteihin PostgreSQL-tietokannan ja Elasticsearch-hakukoneen.
-PostgreSQL-tietokanta käynnistyy test-vars.yml-tiedostossa määritelyyn porttiin (oletuksena 5435).
-Elasticsearch-kontti käynnistetään satunnaiseen porttiin käyttäen TestContainers-työkalua.
-Ennen testien ajamista Elasticsearchiin ladataan dataa, joka on luotu kouta-indeksoijalla käyttäen [ElasticDump-työkalua](https://github.com/elasticsearch-dump/elasticsearch-dump).
+Testejä varten täytyy Docker daemon olla käynnissä ja Kouta-indeksoijan
+Elasticsearch käynnissä (ks. alla). Yksittäisen testisuiten tai testin voi ajaa
+IntelliJ IDEA:ssa halutun testiluokan tai funktion päältä, run -> scalaTest.
+Testien ajaminen käynnistää docker-kontteihin PostgreSQL-tietokannan.
+PostgreSQL-tietokanta käynnistyy test-vars.yml-tiedostossa määritelyyn porttiin
+(oletuksena 5435).
 
 Jos Maven on asennettuna, voi testit ajaa myös komentoriviltä `mvn test` komennolla tai rajaamalla
 ajettavien testejä `mvn test -Dsuites="<testiluokan nimet pilkulla erotettuna>"`.
 Esimerkiksi `mvn test -Dsuites="fi.oph.kouta.external.integration.HakukohdeSpec"`
 
-Koska Elasticsearch-datadumpin lataaminen kestää jonkin aikaa, luku-rajapintojen testejä toteuttaessa kannattaa ajaa testejä valmiiksi käynnistetyllä Elasticsearchilla.
-Katso ohjeet Elasticsearch-kontin käynnistämiseen [kouta-indeksoijan README:sta](https://github.com/Opetushallitus/kouta-indeksoija/#elasticsearch-kontin-käynnistys). 
+#### Elasticsearchin käynnistys
 
-Voit vaihtoehtoisesti käyttää valmista docker-compose-sääntöä (ks. [./docker-compose.yml]) Elasticsearchin ajamiseen:
+Voit käyttää valmista docker-compose-sääntöä (ks. [./docker-compose.yml]) Elasticsearchin ajamiseen:
 ```
 $ docker-compose up -d kouta-elastic
 ```
 
-Ja voit ladata tiedot etukäteen komennolla:
+Mikäli image ei löydy, pitää ensin kirjautua ECR:iin, katso ohjeet [kouta-indeksoijan README:sta](https://github.com/Opetushallitus/kouta-indeksoija/#elasticsearch-kontin-käynnistys). 
+
+Ja voit ladata testidatan etukäteen komennolla:
 ```
 $ docker-compose up elasticdump-loader
 ```
 
 Jos saat virheilmoituksen "Elasticsearch exited unexpectedly." on kyse todennäköisesti muistin loppumisesta.  Vapauta oman koneesi muistia (tai varaa Elastic-kontille lisää muistia) ja yritä uudelleen.
 
-Huom! Jos käytät linuxia ja kouta-indeksoijan ohjeita, vaihda komennon parametri `-p 127.0.0.1:9200:9200` -> `-p 9200:9200`. Muuten elasticdump ei saa yhteyttä elasticsearchiin.
+Koska Elasticsearch-datadumpin lataaminen kestää jonkin aikaa,
+luku-rajapintojen testejä toteuttaessa kannattaa ajaa testejä valmiiksi
+käynnistetyllä Elasticsearchilla.  Jos sen sijaan
+useTestContainersElastic-muuttuja on True, testit käynnistävät
+Elasticsearch-hakukoneen.  Elasticsearch-kontti käynnistetään satunnaiseen
+porttiin käyttäen TestContainers-työkalua.  Ennen testien ajamista
+Elasticsearchiin ladataan dataa, joka on luotu kouta-indeksoijalla käyttäen
+[ElasticDump-työkalua](https://github.com/elasticsearch-dump/elasticsearch-dump).
 
-Aseta sitten muuttuja `useTestContainersElastic = false` täällä: https://github.com/Opetushallitus/kouta-external/blob/master/src/test/scala/fi/oph/kouta/external/TempElastic.scala#L9.
-Nyt voit ajaa testejä ilman jatkuvaa Elasticsearchin uudelleenkäynnistelyä ja dumppien latailua. Muista palauttaa `useTestContainersElastic = true`, kun olet valmis.
+Huom! Jos käytät linuxia ja [kouta-indeksoijan ohjeita](https://github.com/Opetushallitus/kouta-indeksoija/#elasticsearch-kontin-käynnistys), vaihda komennon parametri `-p 127.0.0.1:9200:9200` -> `-p 9200:9200`. Muuten elasticdump ei saa yhteyttä elasticsearchiin.
 
 ### 3.3. Migraatiot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
     volumes:
       - kouta-elastic-data:/usr/share/elasticsearch/data
     ports:
@@ -18,7 +23,8 @@ services:
   elasticdump-loader:
     image: docker.io/elasticdump/elasticsearch-dump:v6.110.0
     depends_on:
-      - kouta-elastic
+      kouta-elastic:
+        condition: service_healthy
     volumes:
       - ./kouta-external/src/test/resources/elastic_dump:/tmp
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+
+volumes:
+  kouta-elastic-data:
+
+services:
+  kouta-elastic:
+    image: 190073735177.dkr.ecr.eu-west-1.amazonaws.com/utility/elasticsearch-kouta:8.5.2
+    container_name: kouta-elasticsearch
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+    volumes:
+      - kouta-elastic-data:/usr/share/elasticsearch/data
+    ports:
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
+
+  elasticdump-loader:
+    image: docker.io/elasticdump/elasticsearch-dump:v6.110.0
+    depends_on:
+      - kouta-elastic
+    volumes:
+      - ./kouta-external/src/test/resources/elastic_dump:/tmp
+    command: >
+      multielasticdump --direction=load --input=/tmp
+      --output=http://kouta-elasticsearch:9200
+      --includeType=data,mapping,alias,settings,template

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/TempElastic.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/TempElastic.scala
@@ -15,7 +15,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.utility.DockerImageName
 
 object TempElasticClient {
-  val useTestContainersElastic = true // Aseta falseksi, jos haluat ajaa testejä jo käynnissä olevaa elasticsearchia vasten
+  val useTestContainersElastic = false // Aseta trueksi, jos haluat että testit käynnistävät itse Elasticsearchin
   var url = ""
   if (useTestContainersElastic) {
     url = s"http://localhost:${TempElastic.start()}"

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,12 @@
             <groupId>com.typesafe.slick</groupId>
             <artifactId>slick_2.12</artifactId>
             <version>${slick.version}</version>
+	    <exclusions>
+		<exclusion>
+		    <groupId>org.reactivestreams</groupId>
+		    <artifactId>reactive-streams</artifactId>
+		</exclusion>
+	    </exclusions>
         </dependency>
         <dependency>
             <groupId>com.typesafe.slick</groupId>
@@ -383,11 +389,6 @@
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>
-                <artifactId>scala-library</artifactId>
-                <version>${scala.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
                 <version>${scala.version}</version>
             </dependency>
@@ -447,22 +448,6 @@
                 <version>3.9</version>
             </dependency>
             <dependency>
-                <groupId>com.typesafe.slick</groupId>
-                <artifactId>slick-hikaricp_2.12</artifactId>
-                <version>${slick.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.typesafe.slick</groupId>
-                <artifactId>slick_2.12</artifactId>
-                <version>${slick.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.reactivestreams</groupId>
-                        <artifactId>reactive-streams</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>com.typesafe</groupId>
                 <artifactId>config</artifactId>
                 <version>1.3.3</version>
@@ -471,11 +456,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.30</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -501,11 +481,6 @@
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>3.22.0-GA</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${jdbc.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.log4s</groupId>


### PR DESCRIPTION
This PR changes the way that kouta-external's test ES is run.

The point of this PR is to:
- Use the same Elasticsearch for both modules (kouta-external & europass-publisher)
- Document in a machine-readable, concise and declarative manner how the test data is seeded (docker-compose.yml)
- provide easy CLI tooling to run the background services needed by kouta-external