### PR TITLE
OK-634: produce Europass learning opportunities from kouta-elastic

### DIFF
--- a/europass-publisher/pom.xml
+++ b/europass-publisher/pom.xml
@@ -52,6 +52,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.blemale</groupId>
+            <artifactId>scaffeine_2.12</artifactId>
+        </dependency>
 
         <!-- Jetty -->
         <dependency>

--- a/europass-publisher/pom.xml
+++ b/europass-publisher/pom.xml
@@ -44,6 +44,10 @@
 	  <groupId>org.http4s</groupId>
 	  <artifactId>http4s-json4s-jackson_2.12</artifactId>
 	</dependency>
+	<dependency>
+	  <groupId>com.typesafe</groupId>
+	  <artifactId>config</artifactId>
+	</dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>

--- a/europass-publisher/src/main/resources/europass-publisher.properties
+++ b/europass-publisher/src/main/resources/europass-publisher.properties
@@ -1,0 +1,3 @@
+europass-publisher.elasticsearch.url = http://localhost:9200
+europass-publisher.elasticsearch.username = none
+europass-publisher.elasticsearch.password = none

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
@@ -32,6 +32,6 @@ object ElasticClient {
   }
 
   def getToteutus(oid: String): Future[JValue] =
-    getJson(s"toteutus-kouta/_doc/$oid")
+    getJson(s"toteutus-kouta/_doc/$oid").map{_ \ "_source"}
 
 }

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
@@ -1,0 +1,34 @@
+package fi.oph.kouta.europass
+
+import org.json4s._
+import org.json4s.jackson.JsonMethods.parse
+import org.asynchttpclient.Dsl._
+import org.asynchttpclient._
+
+import java.util.concurrent.CompletableFuture
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+
+object ElasticClient {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  lazy val elasticUrl = EuropassConfiguration.config.getString("europass-publisher.elasticsearch.url")
+  lazy val username = EuropassConfiguration.config.getString("europass-publisher.elasticsearch.username")
+  lazy val password = EuropassConfiguration.config.getString("europass-publisher.elasticsearch.password")
+  lazy val realm = new Realm.Builder(username, password)
+    .setUsePreemptiveAuth(true)
+    .setScheme(Realm.AuthScheme.BASIC)
+    .build()
+  val httpClient = asyncHttpClient()
+
+  def getJson(urlSuffix: String): Future[JValue] = {
+    val req = get(s"${elasticUrl}/${urlSuffix}").setRealm(realm).build()
+    toScala(httpClient.executeRequest(req).toCompletableFuture)
+      .map {
+        case r if r.getStatusCode == 200 => parse(r.getResponseBodyAsStream())
+        case r => throw new RuntimeException(s"Elasticsearch query $urlSuffix failed: ${r.getResponseBody()}")
+      }
+  }
+
+}

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElasticClient.scala
@@ -31,4 +31,7 @@ object ElasticClient {
       }
   }
 
+  def getToteutus(oid: String): Future[JValue] =
+    getJson(s"toteutus-kouta/_doc/$oid")
+
 }

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConfiguration.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConfiguration.scala
@@ -1,0 +1,8 @@
+package fi.oph.kouta.europass
+
+import com.typesafe.config.ConfigFactory
+
+object EuropassConfiguration {
+  lazy val config = ConfigFactory.load("europass-publisher")
+    .withFallback(ConfigFactory.load("default"))
+}

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
@@ -1,0 +1,23 @@
+package fi.oph.kouta.europass
+
+import java.io.BufferedWriter
+
+object Publisher {
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  def toteutusToFile(oid: String, dest: BufferedWriter) =
+    ElasticClient.getToteutus(oid)
+      .map(EuropassConversion.toteutusAsElmXml)
+      .map{toteutusXml => {
+        dest.write(
+          <loq:Courses xsdVersion="3.1.0"
+              xmlns:loq="http://data.europa.eu/snb/model/ap/loq-constraints/">
+            <loq:learningOpportunityReferences>
+              {toteutusXml}
+            </loq:learningOpportunityReferences>
+          </loq:Courses>.toString
+        )
+        dest.close()
+      }}
+
+}

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConfigurationSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConfigurationSpec.scala
@@ -1,0 +1,10 @@
+package fi.oph.kouta.europass.test
+
+import fi.oph.kouta.europass.EuropassConfiguration
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+
+class ConfigurationSpec extends ScalatraFlatSpec {
+  "configuration" should "have Elasticsearch details" in {
+    assert(EuropassConfiguration.config.getString("europass-publisher.elasticsearch.url").startsWith("http"))
+  }
+}

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
@@ -25,9 +25,10 @@ class ElasticClientSpec extends ScalatraFlatSpec {
 
   "example toteutus" should "be loadable" in {
     Await.result(ElasticClient.getToteutus("1.2.246.562.17.00000000000000000002")
-      .map{result: JValue => assert((result \ "found").extract[Boolean])}, 60.second)
+      .map{result: JValue => assert((result \ "tila").extract[String]
+        == "julkaistu")}, 60.second)
     Await.result(ElasticClient.getToteutus("1.2.246.562.17.00000000000000000002")
-      .map{result: JValue => assert((result \ "_source" \ "koulutusOid").extract[String]
+      .map{result: JValue => assert((result \ "koulutusOid").extract[String]
         == "1.2.246.562.13.00000000000000000001")}, 60.second)
   }
 }

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
@@ -1,0 +1,25 @@
+package fi.oph.kouta.europass.test
+
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+import fi.oph.kouta.europass.ElasticClient
+
+class ElasticClientSpec extends ScalatraFlatSpec {
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val formats = DefaultFormats
+
+  "elasticsearch" should "respond" in {
+    Await.result(ElasticClient.getJson("")
+      .map{_ \ "tagline"}
+      .map{_.extract[String] == "You Know, for Search"}
+      .map{assert(_)}, 60.second)
+    Await.result(ElasticClient.getJson("_cluster/health")
+      .map{_ \ "status"}
+      .map{_.extract[String] == "yellow"}
+      .map{assert(_)}, 60.second)
+  }
+}

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
@@ -22,4 +22,12 @@ class ElasticClientSpec extends ScalatraFlatSpec {
       .map{_.extract[String] == "yellow"}
       .map{assert(_)}, 60.second)
   }
+
+  "example toteutus" should "be loadable" in {
+    Await.result(ElasticClient.getToteutus("1.2.246.562.17.00000000000000000002")
+      .map{result: JValue => assert((result \ "found").extract[Boolean])}, 60.second)
+    Await.result(ElasticClient.getToteutus("1.2.246.562.17.00000000000000000002")
+      .map{result: JValue => assert((result \ "_source" \ "koulutusOid").extract[String]
+        == "1.2.246.562.13.00000000000000000001")}, 60.second)
+  }
 }

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
@@ -1,0 +1,29 @@
+package fi.oph.kouta.europass.test
+
+import org.scalatra.test.scalatest.ScalatraFlatSpec
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import java.io._
+
+import fi.oph.kouta.europass.Publisher
+
+class PublisherSpec extends ScalatraFlatSpec {
+
+  "publisher" should "create correct toteutusXml from ElasticSearch" in {
+    val writer = new StringWriter()
+    Await.result(
+      Publisher.toteutusToFile(
+        "1.2.246.562.17.00000000000000000001", new BufferedWriter(writer)),
+      60.second)
+    assert(writer.toString.contains("<loq:contentUrl>https://opintopolku.fi/konfo/sv/toteutus/1.2.246.562.17.00000000000000000001</loq:contentUrl>"))
+    assert(writer.toString.contains("<loq:providedBy idref=\"https://rdf.oph.fi/organisaatio/1.2.246.562.10.594252633210\"/>"))
+
+    // Want to have the test XML as a file?  Here you go:
+    // val w = new BufferedWriter(new FileWriter("test.txt"))
+    // w.write(writer.toString)
+    // w.close()
+
+  }
+
+}
+


### PR DESCRIPTION
This was also tested by taking the XML from the PublisherSpec (see at the end) and uploading to QDR test environment.  The errors are as expected, except the complaint about needing either `title` or `identifier` is weird, as it doesn't correspond to the [schema](https://europa.eu/europass/elm-browser/documentation/xsd/ap/loq/documentation/loq_xsd.html#homepage).  The errors were:

```
Report item 0:
Message (line 5, column 21): cvc-complex-type.2.4.a: Invalid content was found starting with element '{"http://data.europa.eu/snb/model/ap/loq-constraints/":homepage}'. One of '{"http://data.europa.eu/snb/model/ap/loq-constraints/":identifier, "http://data.europa.eu/snb/model/ap/loq-constraints/":title}' is expected.
Report item 1:
Message (line 20, column 25): cvc-identity-constraint.4.3: Key 'learningOpportunityLearningAchievementSpecificationKeyref' with value 'https://rdf.oph.fi/koulutus/1.2.246.562.13.00000000000000000001' not found for identity constraint of element 'Courses'.
Report item 2:
Message (line 20, column 25): cvc-identity-constraint.4.3: Key 'learningOpportunityProvidedByKeyref' with value 'https://rdf.oph.fi/organisaatio/1.2.246.562.10.67476956288' not found for identity constraint of element 'Courses'.
```

The test XML is:
```
$ cat europass-publisher/test.txt 
<loq:Courses xsdVersion="3.1.0" xmlns:loq="http://data.europa.eu/snb/model/ap/loq-constraints/">
            <loq:learningOpportunityReferences>
              <loq:learningOpportunity id="https://rdf.oph.fi/koulutus-toteutus/1.2.246.562.17.00000000000000000001">
      <loq:homepage>
      <loq:language uri="http://publications.europa.eu/resource/authority/language/ENG"/>
      <loq:contentUrl>https://opintopolku.fi/konfo/en/toteutus/1.2.246.562.17.00000000000000000001</loq:contentUrl>
    </loq:homepage><loq:homepage>
      <loq:language uri="http://publications.europa.eu/resource/authority/language/FIN"/>
      <loq:contentUrl>https://opintopolku.fi/konfo/fi/toteutus/1.2.246.562.17.00000000000000000001</loq:contentUrl>
    </loq:homepage><loq:homepage>
      <loq:language uri="http://publications.europa.eu/resource/authority/language/SWE"/>
      <loq:contentUrl>https://opintopolku.fi/konfo/sv/toteutus/1.2.246.562.17.00000000000000000001</loq:contentUrl>
    </loq:homepage>
      <loq:learningAchievementSpecification idref="https://rdf.oph.fi/koulutus/1.2.246.562.13.00000000000000000001"/>
      <loq:providedBy idref="https://rdf.oph.fi/organisaatio/1.2.246.562.10.67476956288"/><loq:providedBy idref="https://rdf.oph.fi/organisaatio/1.2.246.562.10.594252633210"/>
      <loq:title language="fi">nimi fi</loq:title><loq:title language="sv">nimi sv</loq:title>
    </loq:learningOpportunity>
            </loq:learningOpportunityReferences>
          </loq:Courses>
```