### PR TITLE
OK-757: create XML in a streaming way

### DIFF
--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassPublisherApp.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassPublisherApp.scala
@@ -49,14 +49,11 @@ object EuropassPublisherApp extends Logging {
   }
 
   def main(args : Array[String]) {
-    val future: Future[PutObjectResponse] = Publisher.publishedToteutuksetAsFile()
-      .flatMap{fileName: String => {
-        logger.info(s"Toteutukset dumped in $fileName")
-        toScala(dokumenttipalvelu.putObject(
-          s3Key, fileName, "application/xml", new BufferedInputStream(new FileInputStream(fileName))
-        ))
-      }}
-    val result = Await.result(future, 60.minute)
+    val fileName = Publisher.publishedToteutuksetAsFile()
+    logger.info(s"Toteutukset dumped in $fileName")
+    val result = dokumenttipalvelu.putObject(
+      s3Key, fileName, "application/xml", new BufferedInputStream(new FileInputStream(fileName))
+    ).join()
     logger.info(s"Uploaded to S3 with result $result")
   }
 

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ElasticClientSpec.scala
@@ -33,11 +33,9 @@ class ElasticClientSpec extends ScalatraFlatSpec with ElasticFixture {
   }
 
   "published toteutukset" should "have both toteutukset" in {
-    Await.result(ElasticClient.listPublished(None)
-      .map{result: Stream[JValue] => {
-        assert(result.toArray.length == 2)
-        assert(result.map(_ \ "oid").map(_.extract[String]).toList ==
-          List("1.2.246.562.17.00000000000000000001", "1.2.246.562.17.00000000000000000002"))
-      }}, 60.second)
+    val result = ElasticClient.listPublished(None)
+    assert(result.toArray.length == 2)
+    assert(result.map(_ \ "oid").map(_.extract[String]).toList ==
+      List("1.2.246.562.17.00000000000000000001", "1.2.246.562.17.00000000000000000002"))
   }
 }

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
@@ -28,22 +28,18 @@ class PublisherSpec extends ScalatraFlatSpec with ElasticFixture {
 
   "publishedToteutuksetToFile" should "create XML from ElasticSearch" in {
     val writer = new StringWriter()
-    Await.result(
-      Publisher.publishedToteutuksetToFile(new BufferedWriter(writer)),
-      60.second)
+    Publisher.publishedToteutuksetToFile(new BufferedWriter(writer))
     val content = writer.toString
     assert(content.contains(
-      "<loq:learningOpportunity id=\"https://rdf.oph.fi/koulutus-toteutus/1.2.246.562.17.00000000000000000001\">"
+      "<loq:learningOpportunity id=\"https://rdf.oph.fi/koulutus-toteutus/1.2.246.562.17.00000000000000000001\""
     ))
     assert(content.contains(
-      "<loq:learningOpportunity id=\"https://rdf.oph.fi/koulutus-toteutus/1.2.246.562.17.00000000000000000002\">"
+      "<loq:learningOpportunity id=\"https://rdf.oph.fi/koulutus-toteutus/1.2.246.562.17.00000000000000000002\""
     ))
   }
 
   "publishedToteutuksetAsFile" should "return XML filename" in {
-    val fileName = Await.result(
-      Publisher.publishedToteutuksetAsFile(),
-      60.second)
+    val fileName = Publisher.publishedToteutuksetAsFile()
     assert(fileName.contains("europass-export"))
     val content = Source.fromFile(fileName).mkString
     assert(content.contains("<loq:title language=\"sv\">nimi sv</loq:title>"))


### PR DESCRIPTION
The point of this change is to preserve memory: the old ElasticClient code loaded all toteutukset into the memory at the same time.

Changes publishedToteutukset to a Stream instead of a Future-wrapped Stream; simpler, and easier to make guarantees about when a computation is launched.