### PR TITLE
OK-963: enrich learning opportunities with some optional fields

### DIFF
--- a/europass-publisher/src/main/resources/europass-publisher.properties
+++ b/europass-publisher/src/main/resources/europass-publisher.properties
@@ -5,3 +5,4 @@ europass-publisher.s3.region = eu-west-1
 europass-publisher.s3.bucketname = europass-publish
 europass-publisher.s3.keyname = europass-export-1.xml
 europass-publisher.s3.endpoint = http://localhost:4566
+europass-publisher.publishing.toteutus-extra-fields = true

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -18,6 +18,10 @@ import fi.oph.kouta.logging.Logging
 object EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
 
+  lazy val toteutusExtras = EuropassConfiguration.config.getBoolean(
+    "europass-publisher.publishing.toteutus-extra-fields"
+  )
+
   val langCodes = Map(
     "en" -> List("http://publications.europa.eu/resource/authority/language/ENG"),
     "fi" -> List("http://publications.europa.eu/resource/authority/language/FIN"),

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -126,6 +126,18 @@ object EuropassConversion extends Logging {
     else List()
   }
 
+  def toteutuksenAikatauluAsElmXml(toteutus: ToteutusIndexed): Seq[Elem] = {
+    val opetus: Option[OpetusIndexed] = toteutus.metadata.flatMap(_.opetus)
+    (opetus.map(_.opetusaikaKuvaus).map(_.toList).getOrElse(List()) ++
+      opetus.map(_.opetustapaKuvaus).map(_.toList).getOrElse(List()))
+        .take(1)  // No way to express language alternatives so we just pick a random one
+        .map{case (lang, desc) =>
+          <scheduleInformation>
+            <noteLiteral language={lang.name}>{desc}</noteLiteral>
+          </scheduleInformation>
+        }.toList
+  }
+
   def toteutusAsElmXml(toteutus: ToteutusIndexed): Option[Elem] = {
     val oid: String = toteutus.oid.map(_.toString).getOrElse("")
     val langs = List("en", "fi", "sv")
@@ -142,6 +154,7 @@ object EuropassConversion extends Logging {
       {langs.map(konfoUrl(_, oid))}
       {toteutuksenAjankohtaAsElmXml(toteutus)}
       {toteutuksenKestoAsElmXml(toteutus)}
+      {toteutuksenAikatauluAsElmXml(toteutus)}
       {toteutus.tarjoajat.map{t =>
         <providedBy idref={organisaatioUrl(t.oid.toString)}/>}}
       <learningAchievementSpecification

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -85,6 +85,15 @@ object EuropassConversion extends Logging {
     else default
   }
 
+  def toteutuksenKuvausAsElmXml(toteutus: ToteutusIndexed): Seq[Elem] =
+    toteutus.metadata.map(_.kuvaus) match {
+      case Some(kuvaukset: Kielistetty) if toteutusExtras =>
+        kuvaukset.keys.map{lang =>
+          <description language={lang.name}>{kuvaukset(lang)}</description>
+        }.toList
+      case _ => List()
+    }
+
   def toteutusAsElmXml(toteutus: ToteutusIndexed): Option[Elem] = {
     val oid: String = toteutus.oid.map(_.toString).getOrElse("")
     val langs = List("en", "fi", "sv")
@@ -97,6 +106,7 @@ object EuropassConversion extends Logging {
     } else
     Some(<learningOpportunity id={toteutusUrl(oid)}>
       {nimetAsElmXml(toteutus.nimi)}
+      {toteutuksenKuvausAsElmXml(toteutus)}
       {langs.map(konfoUrl(_, oid))}
       {toteutus.tarjoajat.map{t =>
         <providedBy idref={organisaatioUrl(t.oid.toString)}/>}}

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -7,6 +7,7 @@ import fi.oph.kouta.external.domain.indexed.{
   KoodiUri,
   KoulutusIndexed,
   ToteutusIndexed,
+  OpetusIndexed,
   TutkintoNimike,
   Organisaatio,
   AmmatillinenKoulutusMetadataIndexed,
@@ -115,6 +116,16 @@ object EuropassConversion extends Logging {
       case _ => List()
     }
 
+  def toteutuksenKestoAsElmXml(toteutus: ToteutusIndexed): Seq[Elem] = {
+    val opetus: Option[OpetusIndexed] = toteutus.metadata.flatMap(_.opetus)
+    val duration: String =
+      opetus.flatMap(_.suunniteltuKestoVuodet).map(_ + "Y").getOrElse("") +
+      opetus.flatMap(_.suunniteltuKestoKuukaudet).map(_ + "M").getOrElse("")
+    if (toteutusExtras && duration.nonEmpty)
+      List(<duration>{"P" + duration}</duration>)
+    else List()
+  }
+
   def toteutusAsElmXml(toteutus: ToteutusIndexed): Option[Elem] = {
     val oid: String = toteutus.oid.map(_.toString).getOrElse("")
     val langs = List("en", "fi", "sv")
@@ -130,6 +141,7 @@ object EuropassConversion extends Logging {
       {toteutuksenKuvausAsElmXml(toteutus)}
       {langs.map(konfoUrl(_, oid))}
       {toteutuksenAjankohtaAsElmXml(toteutus)}
+      {toteutuksenKestoAsElmXml(toteutus)}
       {toteutus.tarjoajat.map{t =>
         <providedBy idref={organisaatioUrl(t.oid.toString)}/>}}
       <learningAchievementSpecification

--- a/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
+++ b/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
@@ -1,0 +1,240 @@
+{
+  "tila": "julkaistu",
+  "kuuluuOpintokokonaisuuksiin": [],
+  "liitetytOpintojaksot": [],
+  "oppilaitokset": [
+    "1.2.246.562.10.38417217288"
+  ],
+  "koulutukset": [],
+  "tarjoajat": [
+    {
+      "oid": "1.2.246.562.10.25798690799",
+      "nimi": {
+        "fi": "Avoin yliopisto",
+        "sv": "Avoin yliopisto",
+        "en": "Avoin yliopisto"
+      },
+      "paikkakunta": {
+        "koodiUri": "kunta_564",
+        "nimi": {
+          "sv": "Uleåborg",
+          "fi": "Oulu"
+        }
+      }
+    }
+  ],
+  "liitetytOsaamismerkit": [],
+  "esikatselu": true,
+  "modified": "2023-02-16T15:58:16",
+  "koulutusOid": "1.2.246.562.13.00000000000000004330",
+  "nimi": {
+    "en": "Avoin yo: Statistics toolkit - Tilastotiedepaketti, 1 op, 2022  - 2023 (online course)"
+  },
+  "muokkaaja": {
+    "oid": "1.2.246.562.24.21010340409",
+    "nimi": "Saimi Jokelainen-Testi"
+  },
+  "oid": "1.2.246.562.17.00000000000000012960",
+  "externalId": "ay044116S",
+  "kielivalinta": [
+    "en"
+  ],
+  "haut": [
+    "1.2.246.562.29.00000000000000030509"
+  ],
+  "koulutustyyppiPath": "kk-muu/kk-opintojakso-avoin",
+  "timestamp": 1745275396580,
+  "organisaatiot": [
+    "1.2.246.562.10.25798690799"
+  ],
+  "organisaatio": {
+    "oid": "1.2.246.562.10.25798690799",
+    "nimi": {
+      "fi": "Avoin yliopisto",
+      "sv": "Avoin yliopisto",
+      "en": "Avoin yliopisto"
+    },
+    "paikkakunta": {
+      "koodiUri": "kunta_564",
+      "nimi": {
+        "sv": "Uleåborg",
+        "fi": "Oulu"
+      }
+    }
+  },
+  "metadata": {
+    "kuvaus": {
+      "en": "<p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine.</p>"
+    },
+    "hakutermi": "ilmoittautuminen",
+    "opintojenLaajuusyksikko": {
+      "koodiUri": "opintojenlaajuusyksikko_2#1",
+      "nimi": {
+        "en": "ECTS credits",
+        "fi": "opintopistettä",
+        "sv": "studiepoäng"
+      }
+    },
+    "hakulomaketyyppi": "muu",
+    "aloituspaikkakuvaus": {},
+    "hakulomakeLinkki": {
+      "en": "https://www.oulu.fi/en/joy/education-search/statistics-toolkit-open-uni-tilastotiedepaketti-avoin-yo"
+    },
+    "hakuaika": {
+      "alkaa": "2023-01-01T00:00",
+      "paattyy": "2023-05-31T23:59",
+      "formatoituPaattyy": {
+        "fi": "31.5.2023 klo 23:59",
+        "sv": "31.5.2023 kl. 23:59",
+        "en": "May. 31, 2023 at 11:59 PM UTC+3"
+      },
+      "formatoituAlkaa": {
+        "fi": "1.1.2023 klo 00:00",
+        "sv": "1.1.2023 kl. 00:00",
+        "en": "Jan. 1, 2023 at 12:00 AM UTC+2"
+      }
+    },
+    "opintojenLaajuusNumero": 1,
+    "isAvoinKorkeakoulutus": true,
+    "isMuokkaajaOphVirkailija": false,
+    "ammattinimikkeet": [],
+    "asiasanat": [
+      {
+        "kieli": "en",
+        "arvo": "evidence based medicine"
+      },
+      {
+        "kieli": "en",
+        "arvo": "Statistics toolkit"
+      },
+      {
+        "kieli": "en",
+        "arvo": "ay044116S"
+      },
+      {
+        "kieli": "en",
+        "arvo": "oulu open university"
+      }
+    ],
+    "lisatietoaValintaperusteista": {},
+    "lisatietoaHakeutumisesta": {
+      "en": "<p>&#x27;</p>"
+    },
+    "isTyovoimakoulutus": false,
+    "hasJotpaRahoitus": false,
+    "isTaydennyskoulutus": false,
+    "tunniste": "ay044116S",
+    "opetus": {
+      "maksullisuustyyppi": "maksuton",
+      "maksullisuusKuvaus": {},
+      "suunniteltuKestoKuvaus": {
+        "en": "<p>There is a continuous registration for the course until 31.5.2023.</p>"
+      },
+      "suunniteltuKestoVuodet": 0,
+      "onkoApuraha": false,
+      "lisatiedot": [
+        {
+          "otsikko": {
+            "koodiUri": "koulutuksenlisatiedot_13#1",
+            "nimi": {
+              "en": "Learning Outcomes",
+              "sv": "Mål",
+              "fi": "Osaamistavoitteet"
+            }
+          },
+          "teksti": {
+            "en": "<p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine.</p>"
+          }
+        },
+        {
+          "otsikko": {
+            "koodiUri": "koulutuksenlisatiedot_12#1",
+            "nimi": {
+              "en": "Content",
+              "sv": "Innehåll",
+              "fi": "Sisältö"
+            }
+          },
+          "teksti": {
+            "en": "<p>The book includes the basic idea of the most usual statistical methods that are used when practicing evidence based medicine.</p><p></p>"
+          }
+        }
+      ],
+      "suunniteltuKestoKuukaudet": 0,
+      "opetustapaKuvaus": {
+        "en": "<p>Online course. <br/>The students read the book Statistics Toolkit (Perera  R, Heneghan C &amp; Badenoch D, ed), BMJ Books, Blackwell Publishing  2008 (e-Book in library) and go through a question series in Moodle  learning environment. The system gives the student feedback on the  answers and tells whether she/he has passed or failed the course.</p><p>27 h of independent work including online exam in Moodle.</p>"
+      },
+      "opetuskieletKuvaus": {},
+      "opetustapa": [
+        {
+          "koodiUri": "opetuspaikkakk_5#1",
+          "nimi": {
+            "fi": "Itsenäinen opiskelu",
+            "en": "Independent learning",
+            "sv": "Självständiga studier"
+          }
+        },
+        {
+          "koodiUri": "opetuspaikkakk_3#1",
+          "nimi": {
+            "fi": "Verkko-opetus",
+            "sv": "Nätundervisning",
+            "en": "Online teaching"
+          }
+        }
+      ],
+      "opetusaikaKuvaus": {},
+      "opetuskieli": [
+        {
+          "koodiUri": "oppilaitoksenopetuskieli_4#2",
+          "nimi": {
+            "en": "English",
+            "sv": "engelska",
+            "fi": "englanti"
+          }
+        }
+      ],
+      "opetusaika": [
+        {
+          "koodiUri": "opetusaikakk_5#1",
+          "nimi": {
+            "sv": "Oberoende av klockslag",
+            "en": "Irrespective of time",
+            "fi": "Kellonajasta riippumaton"
+          }
+        }
+      ]
+    },
+    "yhteyshenkilot": [
+      {
+        "nimi": {
+          "en": "Oulu Open University"
+        },
+        "titteli": {},
+        "sahkoposti": {
+          "en": "avoin.yliopisto@oulu.fi"
+        },
+        "puhelinnumero": {},
+        "wwwSivu": {
+          "en": "https://www.oulu.fi/en/joy/open-university"
+        },
+        "wwwSivuTeksti": {}
+      }
+    ],
+    "tyyppi": "kk-opintojakso",
+    "opinnonTyyppi": {
+      "koodiUri": "opinnontyyppi_3#1",
+      "nimi": {
+        "sv": "Fördjupade studier",
+        "fi": "Syventävät opinnot",
+        "en": "Advanced studies"
+      }
+    }
+  },
+  "formatoituModified": {
+    "fi": "16.2.2023 klo 15:58",
+    "sv": "16.2.2023 kl. 15:58",
+    "en": "Feb. 16, 2023 at 03:58 PM UTC+2"
+  },
+  "koulutustyyppi": "kk-opintojakso"
+}

--- a/europass-publisher/src/test/resources/toteutus-tarkka-alkuaika.json
+++ b/europass-publisher/src/test/resources/toteutus-tarkka-alkuaika.json
@@ -1,0 +1,318 @@
+{
+  "tila": "julkaistu",
+  "kuuluuOpintokokonaisuuksiin": null,
+  "liitetytOpintojaksot": [],
+  "oppilaitokset": [
+    "1.2.246.562.10.2013110715495487451932"
+  ],
+  "teemakuva": "https://konfo-files.opintopolku.fi/toteutus-teemakuva/1.2.246.562.17.00000000000000000035/99108d9c-f138-475a-b34b-4535e98e9b21.jpg",
+  "koulutukset": [
+    {
+      "koodiUri": "koulutus_384446#7",
+      "nimi": {
+        "en": "Further vocational qualification in the Transport Sector",
+        "fi": "Kuljetusalan ammattitutkinto",
+        "sv": "Yrkesexamen inom transportbranschen"
+      }
+    }
+  ],
+  "tarjoajat": [
+    {
+      "oid": "1.2.246.562.10.2013111416014448745197",
+      "nimi": {
+        "sv": "Taivalkosken yksikkö",
+        "fi": "Taivalkosken yksikkö",
+        "en": "Taivalkosken yksikkö"
+      },
+      "paikkakunta": {
+        "koodiUri": "kunta_832",
+        "nimi": {
+          "fi": "Taivalkoski",
+          "sv": "Taivalkoski"
+        }
+      }
+    }
+  ],
+  "liitetytOsaamismerkit": [],
+  "esikatselu": false,
+  "modified": "2022-07-12T20:02:10",
+  "koulutusOid": "1.2.246.562.13.00000000000000000079",
+  "nimi": {
+    "fi": "Kuljetusalan ammattitutkinto, Metsäteollisuuden kuljetusten osaamisala"
+  },
+  "muokkaaja": {
+    "oid": "1.2.246.562.24.22266136615",
+    "nimi": "Anonymisoitu Virkailija"
+  },
+  "oid": "1.2.246.562.17.00000000000000000035",
+  "kielivalinta": [
+    "fi"
+  ],
+  "haut": [
+    "1.2.246.562.29.00000000000000000091"
+  ],
+  "koulutustyyppiPath": "amm/ammattitutkinto",
+  "timestamp": 1745533252264,
+  "organisaatiot": [
+    "1.2.246.562.10.2013110715495487451932",
+    "1.2.246.562.10.2013111416014448745197"
+  ],
+  "organisaatio": {
+    "oid": "1.2.246.562.10.2013110715495487451932",
+    "nimi": {
+      "fi": "OSAO",
+      "sv": "OSAO",
+      "en": "OSAO"
+    },
+    "paikkakunta": {
+      "koodiUri": "kunta_564",
+      "nimi": {
+        "sv": "Uleåborg",
+        "fi": "Oulu"
+      }
+    }
+  },
+  "metadata": {
+    "kuvaus": {},
+    "osaamisalat": [
+      {
+        "koodi": {
+          "koodiUri": "osaamisala_2317",
+          "nimi": {
+            "sv": "Kompetensområdet för skogsindustrins transporter",
+            "fi": "Metsäteollisuuden kuljetusten osaamisala"
+          }
+        },
+        "linkki": {},
+        "otsikko": {}
+      }
+    ],
+    "ammattinimikkeet": [
+      {
+        "kieli": "fi",
+        "arvo": "puutavara-autonkuljetttaja"
+      }
+    ],
+    "asiasanat": [],
+    "isTyovoimakoulutus": false,
+    "isTaydennyskoulutus": false,
+    "opetus": {
+      "maksullisuustyyppi": "maksuton",
+      "maksullisuusKuvaus": {},
+      "suunniteltuKestoKuvaus": {
+        "fi": "<p>Sinulle laaditaan opintojen alussa henkilökohtainen osaamisen kehittämissuunnitelma (HOKS), jossa tunnistetaan ja tunnustetaan aiempi osaamisesi ja todetaan millaista osaamista tutkinnon muodostumiseen tarvitset. Tämä määrittää opiskeluaikasi.</p>"
+      },
+      "koulutuksenAlkamiskausi": {
+        "alkamiskausityyppi": "tarkka alkamisajankohta",
+        "henkilokohtaisenSuunnitelmanLisatiedot": {},
+        "koulutuksenAlkamispaivamaara": "2021-08-04T12:00",
+        "koulutuksenPaattymispaivamaara": "2022-12-22T00:00",
+        "formatoituKoulutuksenalkamispaivamaara": {
+          "fi": "4.8.2021 klo 12:00",
+          "sv": "4.8.2021 kl. 12:00",
+          "en": "Aug. 4, 2021 at 12:00 PM UTC+3"
+        },
+        "formatoituKoulutuksenpaattymispaivamaara": {
+          "fi": "22.12.2022 klo 00:00",
+          "sv": "22.12.2022 kl. 00:00",
+          "en": "Dec. 22, 2022 at 12:00 AM UTC+2"
+        }
+      },
+      "suunniteltuKestoVuodet": 2,
+      "onkoApuraha": false,
+      "lisatiedot": [],
+      "suunniteltuKestoKuukaudet": 0,
+      "opetustapaKuvaus": {},
+      "opetuskieletKuvaus": {
+        "fi": "<p> </p>"
+      },
+      "opetustapa": [
+        {
+          "koodiUri": "opetuspaikkakk_1#1",
+          "nimi": {
+            "fi": "Lähiopetus",
+            "sv": "Närundervisning",
+            "en": "Contact teaching"
+          }
+        }
+      ],
+      "opetusaikaKuvaus": {
+        "fi": "<p> </p>"
+      },
+      "opetuskieli": [
+        {
+          "koodiUri": "oppilaitoksenopetuskieli_1#1",
+          "nimi": {
+            "sv": "finska",
+            "fi": "suomi",
+            "en": "Finnish"
+          }
+        }
+      ],
+      "opetusaika": [
+        {
+          "koodiUri": "opetusaikakk_1#1",
+          "nimi": {
+            "sv": "Dagundervisning",
+            "en": "Day time teaching",
+            "fi": "Päiväopetus"
+          }
+        }
+      ]
+    },
+    "yhteyshenkilot": [],
+    "tyyppi": "amm",
+    "ammatillinenPerustutkintoErityisopetuksena": false
+  },
+  "hakutiedot": [
+    {
+      "hakuOid": "1.2.246.562.29.00000000000000000091",
+      "nimi": {
+        "fi": "Kuljetusalan ammattitutkinto, metsäteollisuuden kuljetusten osaamisala"
+      },
+      "hakutapa": {
+        "koodiUri": "hakutapa_03#1",
+        "nimi": {
+          "en": "Rolling admission (upper secondary level)",
+          "fi": "Jatkuva haku",
+          "sv": "Kontinuerlig ansökan"
+        }
+      },
+      "koulutuksenAlkamiskausi": {
+        "alkamiskausityyppi": "tarkka alkamisajankohta",
+        "henkilokohtaisenSuunnitelmanLisatiedot": {},
+        "koulutuksenAlkamispaivamaara": "2021-08-04T00:00",
+        "koulutuksenPaattymispaivamaara": "2022-12-21T00:00",
+        "formatoituKoulutuksenalkamispaivamaara": {
+          "fi": "4.8.2021 klo 00:00",
+          "sv": "4.8.2021 kl. 00:00",
+          "en": "Aug. 4, 2021 at 12:00 AM UTC+3"
+        },
+        "formatoituKoulutuksenpaattymispaivamaara": {
+          "fi": "21.12.2022 klo 00:00",
+          "sv": "21.12.2022 kl. 00:00",
+          "en": "Dec. 21, 2022 at 12:00 AM UTC+2"
+        }
+      },
+      "kohdejoukko": {
+        "koodiUri": "haunkohdejoukko_23#1",
+        "nimi": {
+          "fi": "Ammatillinen koulutus",
+          "sv": "Yrkesinriktad utbildning"
+        }
+      },
+      "hakukohteet": [
+        {
+          "tila": "arkistoitu",
+          "hakulomakeKuvaus": {},
+          "pohjakoulutusvaatimusTarkenne": {},
+          "aloituspaikat": {
+            "lukumaara": 5,
+            "kuvaus": {}
+          },
+          "hakulomaketyyppi": "muu",
+          "pohjakoulutusvaatimus": [
+            {
+              "koodiUri": "pohjakoulutusvaatimuskouta_pk#1",
+              "nimi": {
+                "fi": "Peruskoulu",
+                "sv": "Grundskola",
+                "en": "Peruskoulu"
+              }
+            }
+          ],
+          "hakulomakeLinkki": {
+            "fi": "https://osao.inschool.fi/apply?school-id=21&long-term=6591&checkout=true"
+          },
+          "jarjestyspaikkaHierarkiaNimi": {
+            "sv": "OSAO, Taivalkosken yksikkö",
+            "fi": "OSAO, Taivalkosken yksikkö",
+            "en": "OSAO, Taivalkosken yksikkö"
+          },
+          "koulutuksenAlkamiskausi": {
+            "alkamiskausityyppi": "tarkka alkamisajankohta",
+            "henkilokohtaisenSuunnitelmanLisatiedot": {},
+            "koulutuksenAlkamispaivamaara": "2021-08-04T00:00",
+            "koulutuksenPaattymispaivamaara": "2022-12-21T00:00",
+            "formatoituKoulutuksenalkamispaivamaara": {
+              "fi": "4.8.2021 klo 00:00",
+              "sv": "4.8.2021 kl. 00:00",
+              "en": "Aug. 4, 2021 at 12:00 AM UTC+3"
+            },
+            "formatoituKoulutuksenpaattymispaivamaara": {
+              "fi": "21.12.2022 klo 00:00",
+              "sv": "21.12.2022 kl. 00:00",
+              "en": "Dec. 21, 2022 at 12:00 AM UTC+2"
+            }
+          },
+          "esikatselu": false,
+          "hasValintaperustekuvausData": false,
+          "modified": "2023-02-07T15:56:20",
+          "jarjestyspaikka": {
+            "oid": "1.2.246.562.10.2013111416014448745197",
+            "nimi": {
+              "sv": "Taivalkosken yksikkö",
+              "fi": "Taivalkosken yksikkö",
+              "en": "Taivalkosken yksikkö"
+            },
+            "paikkakunta": {
+              "koodiUri": "kunta_832",
+              "nimi": {
+                "fi": "Taivalkoski",
+                "sv": "Taivalkoski"
+              }
+            },
+            "jarjestaaUrheilijanAmmKoulutusta": false
+          },
+          "nimi": {
+            "fi": "Kuljetusalan ammattitutkinto, Metsäteollisuuden kuljetusten osaamisala"
+          },
+          "hakuajat": [
+            {
+              "alkaa": "2021-03-16T07:00",
+              "paattyy": "2021-05-16T23:59",
+              "formatoituPaattyy": {
+                "fi": "16.5.2021 klo 23:59",
+                "sv": "16.5.2021 kl. 23:59",
+                "en": "May. 16, 2021 at 11:59 PM UTC+3"
+              },
+              "formatoituAlkaa": {
+                "fi": "16.3.2021 klo 07:00",
+                "sv": "16.3.2021 kl. 07:00",
+                "en": "Mar. 16, 2021 at 07:00 AM UTC+2"
+              }
+            }
+          ],
+          "hakukohdeOid": "1.2.246.562.20.00000000000000000092",
+          "organisaatio": {
+            "oid": "1.2.246.562.10.2013110715495487451932",
+            "nimi": {
+              "fi": "OSAO",
+              "sv": "OSAO",
+              "en": "OSAO"
+            },
+            "paikkakunta": {
+              "koodiUri": "kunta_564",
+              "nimi": {
+                "sv": "Uleåborg",
+                "fi": "Oulu"
+              }
+            }
+          },
+          "formatoituModified": {
+            "fi": "7.2.2023 klo 15:56",
+            "sv": "7.2.2023 kl. 15:56",
+            "en": "Feb. 7, 2023 at 03:56 PM UTC+2"
+          },
+          "valintaperusteId": "e94fd3d5-bf68-4f55-a9ee-b065c355fc93"
+        }
+      ]
+    }
+  ],
+  "formatoituModified": {
+    "fi": "12.7.2022 klo 20:02",
+    "sv": "12.7.2022 kl. 20:02",
+    "en": "Jul. 12, 2022 at 08:02 PM UTC+3"
+  },
+  "koulutustyyppi": "amm"
+}

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -23,6 +23,13 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     read[ToteutusIndexed](resource("toteutus-example-1.json"))
   lazy val toteutusArchived =
     read[ToteutusIndexed](resource("toteutus-arkistoitu.json"))
+  lazy val toteutusWithoutTarjoajat =
+    read[ToteutusIndexed](resource("toteutus-ei-tarjoajia.json"))
+  lazy val toteutusWithoutOpetuskieli =
+    read[ToteutusIndexed](resource("toteutus-ei-opetuskielta.json"))
+  lazy val toteutusTotallyOrdinary =
+    read[ToteutusIndexed](resource("toteutus-ihan-tavanomainen.json"))
+
   lazy val example_koulutus =
     read[KoulutusIndexed](resource("koulutus-example-1.json"))
   lazy val koulutusWithoutKoulutusKoodi =
@@ -35,10 +42,6 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     read[KoulutusIndexed](resource("koulutus-2032.json"))
   lazy val koulutusWithTutkintonimike =
     read[KoulutusIndexed](resource("koulutus-1293.json"))
-  lazy val toteutusWithoutTarjoajat =
-    read[ToteutusIndexed](resource("toteutus-ei-tarjoajia.json"))
-  lazy val toteutusWithoutOpetuskieli =
-    read[ToteutusIndexed](resource("toteutus-ei-opetuskielta.json"))
 
   "example_koulutus" should "have correct fields" in {
     assert(example_koulutus.oid.getOrElse("").toString
@@ -57,6 +60,11 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
       == "http://data.europa.eu/snb/isced-f/02")
     assert((koulutusXml \ "learningOutcome")(0) \@ "idref"
       == "https://rdf.oph.fi/koulutus-tulos/1.2.246.562.13.00000000000000000006")
+  }
+
+  "totally ordinary toteutus" should "have all optional fields" in {
+    val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
+    assert(toteutusXml \ "description" \@ "language" == "en")
   }
 
   "example_toteutus" should "have correct fields" in {

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -29,6 +29,8 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     read[ToteutusIndexed](resource("toteutus-ei-opetuskielta.json"))
   lazy val toteutusTotallyOrdinary =
     read[ToteutusIndexed](resource("toteutus-ihan-tavanomainen.json"))
+  lazy val toteutusExactStartTime =
+    read[ToteutusIndexed](resource("toteutus-tarkka-alkuaika.json"))
 
   lazy val example_koulutus =
     read[KoulutusIndexed](resource("koulutus-example-1.json"))
@@ -103,6 +105,12 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
       == "http://publications.europa.eu/resource/authority/language/FIN")
   }
 
+  it should "have optional elements" in {
+    val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(example_toteutus)
+    assert((toteutusXml \ "temporal" \ "startDate").text == "2023-01-01T00:00:00")
+    assert((toteutusXml \ "temporal" \ "endDate").toList == List())
+  }
+
   it should "have correct tarjoaja" in {
     val tarjoaja: Elem =
       EuropassConversion.toteutusToTarjoajaDependents(example_toteutus)
@@ -117,6 +125,12 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
   it should "have certain koulutus as its dependent" in {
     assert(EuropassConversion.toteutusToKoulutusDependents(example_toteutus)
       == List("1.2.246.562.13.00000000000000000001"))
+  }
+
+  "toteutus with exact start time" should "have exact start time" in {
+    val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(toteutusExactStartTime)
+    assert((toteutusXml \ "temporal" \ "startDate").text == "2021-08-04T12:00:00")
+    assert((toteutusXml \ "temporal" \ "endDate").text == "2022-12-22T00:00:00")
   }
 
   "toteutus without tarjoajat" should "not procude an ELM record" in {

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -67,6 +67,7 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
   "totally ordinary toteutus" should "have all optional fields" in {
     val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
+    assert((toteutusXml \ "duration").text == "P0Y0M")
   }
 
   "example_toteutus" should "have correct fields" in {
@@ -109,6 +110,7 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(example_toteutus)
     assert((toteutusXml \ "temporal" \ "startDate").text == "2023-01-01T00:00:00")
     assert((toteutusXml \ "temporal" \ "endDate").toList == List())
+    assert((toteutusXml \ "duration").text == "P3Y10M")
   }
 
   it should "have correct tarjoaja" in {

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -68,6 +68,10 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     val Some(toteutusXml: Elem) = EuropassConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
     assert((toteutusXml \ "duration").text == "P0Y0M")
+    // from opetustapaKuvaus, since it doesn't have opetusaikaKuvaus
+    assert(toteutusXml \ "scheduleInformation" \ "noteLiteral" \@ "language" == "en")
+    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text
+      .startsWith("<p>Online course."))
   }
 
   "example_toteutus" should "have correct fields" in {
@@ -111,6 +115,8 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     assert((toteutusXml \ "temporal" \ "startDate").text == "2023-01-01T00:00:00")
     assert((toteutusXml \ "temporal" \ "endDate").toList == List())
     assert((toteutusXml \ "duration").text == "P3Y10M")
+    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text
+      == "Opetusaikakuvaus fi")
   }
 
   it should "have correct tarjoaja" in {

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <scala-test.version>3.1.1</scala-test.version>
         <scalatra-scalatest.version>2.7.0</scalatra-scalatest.version>
         <spec2.version>4.2.0</spec2.version>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.57.v20241219</jetty.version>
         <testcontainers.version>1.15.3</testcontainers.version>
         <mockserver-netty.version>5.5.1</mockserver-netty.version>
         <commons.io.version>2.6</commons.io.version>


### PR DESCRIPTION
This PR adds the following fields to learning opportunities:
- description
- temporal (timespan over which the koulutustoteutus is given)
- duration (how long the koulutustoteutus will take for oppija)
- schedule information (freetext description of how much time participation will take, possibly also more precise schedule details such as weekdays or contact teaching)