### PR TITLE
OK-985: creating smaller datasets (for testing purposes)

### DIFF
--- a/europass-publisher/src/main/resources/europass-publisher.properties
+++ b/europass-publisher/src/main/resources/europass-publisher.properties
@@ -6,3 +6,5 @@ europass-publisher.s3.bucketname = europass-publish
 europass-publisher.s3.keyname = europass-export-1.xml
 europass-publisher.s3.endpoint = http://localhost:4566
 europass-publisher.publishing.toteutus-extra-fields = true
+europass-publisher.retrieval.use-toteutus-limit = false
+europass-publisher.retrieval.toteutus-limit = 0

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <scala.compat.version>2.12</scala.compat.version>
 
-        <kouta-common.version>2.21.0-SNAPSHOT</kouta-common.version>
+        <kouta-common.version>2.22.0-SNAPSHOT</kouta-common.version>
 
         <!-- Utility properties -->
         <json4s.version>3.6.11</json4s.version>


### PR DESCRIPTION
PR lisää parametrit, joilla voi rajoittaa exportiin tulevien toteutusten määrää (QDR-portaalilla on joskus vaikeuksia suurten export-tiedostojen kanssa).

Testattu ajamalla lokaalisti palleron elasticia vasten ja tekemällä ensin täysi export, sitten 20 toteutuksen export.