### PR TITLE
OK-1089 Massatuonti-rajapinnat

### DIFF
--- a/kouta-external/src/main/resources/oph-configuration/kouta-external.properties.template
+++ b/kouta-external/src/main/resources/oph-configuration/kouta-external.properties.template
@@ -5,6 +5,8 @@ kouta-external.cas.password={{kouta_external_cas_password}}
 
 kouta-external.hakukohderyhma.cacheTtlMinutes={{kouta_external_hakukohderyhma_cache_ttl_minutes | default('30')}}
 
+kouta-external.massoperation.numThreads={{kouta_external_massoperation_num_threads | default('3')}}
+
 kouta-external.db.url=jdbc:postgresql://{{host_postgresql_koutaexternal}}:{{host_postgresql_koutaexternal_port}}/koutaexternal
 kouta-external.db.port={{host_postgresql_koutaexternal_port}}
 kouta-external.db.user={{postgres_app_user}}

--- a/kouta-external/src/main/scala/ScalatraBootstrap.scala
+++ b/kouta-external/src/main/scala/ScalatraBootstrap.scala
@@ -15,10 +15,13 @@ class ScalatraBootstrap extends LifeCycle {
     context.mount(new AuthServlet(), "/auth", "auth")
 
     context.mount(KoulutusServlet, "/koulutus", "koulutus")
+    context.mount(MassKoulutusServlet, "/koulutukset", "koulutukset")
     context.mount(ValintaperusteServlet, "/valintaperuste", "valintaperuste")
     context.mount(HakuServlet, "/haku", "haku")
     context.mount(HakukohdeServlet, "/hakukohde", "hakukohde")
+    context.mount(MassHakukohdeServlet, "/hakukohteet", "hakukohteet")
     context.mount(ToteutusServlet, "/toteutus", "toteutus")
+    context.mount(MassToteutusServlet, "/toteutukset", "toteutukset")
     context.mount(SorakuvausServlet, "/sorakuvaus", "sorakuvaus")
 
     context.mount(HealthcheckServlet, "/healthcheck", "healthcheck")

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/domain/enums/MassResult.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/domain/enums/MassResult.scala
@@ -1,0 +1,154 @@
+package fi.oph.kouta.external.domain.enums
+
+import fi.oph.kouta.domain.oid.Oid
+import fi.oph.kouta.external.swagger.SwaggerModel
+
+@SwaggerModel(
+  """    MassResult:
+    |      type: array
+    |      items:
+    |        oneOf:
+    |          - type: object
+    |            description: Onnistunut luonti
+    |            required:
+    |              - operation
+    |              - success
+    |              - oid
+    |            properties:
+    |              operation:
+    |                const: CREATE
+    |              success:
+    |                type: boolean
+    |                const: true
+    |                description: Onnistuiko pyynnön käsittely
+    |              oid:
+    |                type: string
+    |                description: Uuden objektin yksilöivä oid
+    |                example: 1.2.246.562.13.00000000000000000009
+    |              externalId:
+    |                type: string
+    |                description: Pyynnössä annettu externalId
+    |          - type: object
+    |            description: Onnistunut päivitys
+    |            required:
+    |              - operation
+    |              - success
+    |              - updated
+    |              - oid
+    |            properties:
+    |              operation:
+    |                const: UPDATE
+    |              success:
+    |                type: boolean
+    |                const: true
+    |                description: Onnistuiko pyynnön käsittely
+    |              oid:
+    |                type: string
+    |                description: Pyynnössä annettu yksilöivä tunniste
+    |                example: 1.2.246.562.13.00000000000000000009
+    |              externalId:
+    |                type: string
+    |                description: Pyynnössä annettu externalId
+    |              updated:
+    |                type: boolean
+    |                description: Oliko objektissa päivitettävää
+    |                example: true
+    |          - type: object
+    |            description: Virhe objektia talletettaessa. Objektia ei ole lisätty / päivitetty.
+    |            required:
+    |              - operation
+    |              - success
+    |              - status
+    |              - message
+    |            properties:
+    |              operation:
+    |                enum: [CREATE, UPDATE]
+    |              success:
+    |                type: boolean
+    |                const: false
+    |                description: Onnistuiko pyynnön käsittely
+    |              oid:
+    |                type: string
+    |                description: Pyynnössä annettu yksilöivä tunniste
+    |                example: 1.2.246.562.13.00000000000000000009
+    |              externalId:
+    |                type: string
+    |                description: Pyynnössä annettu externalId
+    |              status:
+    |                type: int
+    |                description: HTTP-vastauskoodi loppupalvelimelta
+    |                example: 403
+    |              message:
+    |                type: string
+    |                description: Vastauksen sisältö loppupalvelimelta
+    |          - type: object
+    |            description: Odottamaton virhe. Objekti voi olla talletettu tai sitten ei.
+    |            required:
+    |              - operation
+    |              - success
+    |              - exception
+    |            properties:
+    |              operation:
+    |                enum: [CREATE, UPDATE]
+    |              success:
+    |                type: boolean
+    |                const: false
+    |                description: Onnistuiko pyynnön käsittely
+    |              oid:
+    |                type: string
+    |                description: Pyynnössä annettu yksilöivä tunniste
+    |                example: 1.2.246.562.13.00000000000000000009
+    |              externalId:
+    |                type: string
+    |                description: Pyynnössä annettu externalId
+    |              exception:
+    |                type: string
+    |                description: Tapahtuneen virheen tyyppi
+    |                example: java.lang.IllegalArgumentException
+    |""")
+sealed abstract class MassResult(operation: Operation, success: Boolean)
+
+object MassResult {
+  case class UpdateSuccess(
+      operation: Operation,
+      success: Boolean,
+      oid: Oid,
+      externalId: Option[String],
+      updated: Boolean
+  ) extends MassResult(operation, success)
+
+  object UpdateSuccess {
+    def apply(oid: Oid, externalId: Option[String], updated: Boolean): UpdateSuccess =
+      UpdateSuccess(Operation.Update, success = true, oid, externalId, updated = updated)
+  }
+
+  case class CreateSuccess(operation: Operation, success: Boolean, oid: Oid, externalId: Option[String])
+      extends MassResult(operation, success)
+
+  object CreateSuccess {
+    def apply(oid: Oid, externalId: Option[String]): CreateSuccess =
+      CreateSuccess(Operation.Create, success = true, oid = oid, externalId = externalId)
+  }
+
+  case class Failure(
+      operation: Operation,
+      success: Boolean,
+      oid: Option[Oid],
+      externalId: Option[String],
+      status: Int,
+      message: String
+  ) extends MassResult(operation, success)
+
+  object Failure {
+    def apply(operation: Operation, oid: Option[Oid], externalId: Option[String], status: Int, message: String): Failure =
+      Failure(operation, success = false, oid, externalId, status, message)
+  }
+
+  case class Error(operation: Operation, success: Boolean, oid: Option[Oid], externalId: Option[String], exception: String)
+      extends MassResult(operation, success)
+
+  object Error {
+    def apply(operation: Operation, oid: Option[Oid], externalId: Option[String], exception: Throwable): Error =
+      Error(operation, success = false, oid, externalId, exception.getClass.getCanonicalName)
+  }
+}

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/domain/enums/Operation.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/domain/enums/Operation.scala
@@ -1,0 +1,11 @@
+package fi.oph.kouta.external.domain.enums
+
+sealed abstract class Operation(override val name: String) extends BasicType
+
+object Operation extends BasicTypeCompanion[Operation] {
+  case object Update extends Operation("UPDATE")
+
+  case object Create extends Operation("CREATE")
+
+  override def all: List[Operation] = List(Update, Create)
+}

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/domain/perustiedot.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/domain/perustiedot.scala
@@ -16,10 +16,11 @@ sealed trait Perustiedot[ID, T] extends AuthorizableEntity[T] {
   val kielivalinta: Seq[Kieli]
   val organisaatioOid: OrganisaatioOid
   val modified: Option[Modified]
+  val externalId: Option[String]
 }
 
 abstract class PerustiedotWithOid[ID <: Oid, T] extends Perustiedot[ID, T] {
-  val oid: Option[Oid]
+  val oid: Option[ID]
 }
 
 abstract class PerustiedotWithId[T] extends Perustiedot[UUID, T] {

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/koutaConfiguration.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/koutaConfiguration.scala
@@ -37,6 +37,8 @@ case class CasClientConfiguration(username: String, password: String)
 
 case class HakukohderyhmaConfiguration(cacheTtlMinutes: Long)
 
+case class MassOperationConfiguration(numThreds: Int)
+
 case class KoutaConfiguration(config: TypesafeConfig, urlProperties: OphProperties)
     extends KoutaBaseConfig(config, urlProperties) {
 
@@ -75,6 +77,10 @@ case class KoutaConfiguration(config: TypesafeConfig, urlProperties: OphProperti
   val clientConfiguration = CasClientConfiguration(
     username = config.getString("kouta-external.cas.username"),
     password = config.getString("kouta-external.cas.password")
+  )
+
+  val massOperationConfiguration = MassOperationConfiguration(
+    numThreds = config.getInt("kouta-external.massoperation.numThreads")
   )
 }
 

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/service/HakukohdeService.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/service/HakukohdeService.scala
@@ -4,7 +4,7 @@ import fi.oph.kouta.domain.Julkaisutila
 import fi.oph.kouta.domain.oid.{HakuOid, HakukohdeOid, HakukohderyhmaOid, OrganisaatioOid}
 import fi.oph.kouta.external.domain.Hakukohde
 import fi.oph.kouta.external.elasticsearch.HakukohdeClient
-import fi.oph.kouta.external.kouta._
+import fi.oph.kouta.external.kouta.{CasKoutaClient, KoutaHakukohdeRequest, KoutaResponse, OidResponse, UpdateResponse, UuidResponse}
 import fi.oph.kouta.security.Role.Indexer
 import fi.oph.kouta.security.{Role, RoleEntity}
 import fi.oph.kouta.service.{AuthorizationRules, OrganisaatioService, OrganizationAuthorizationFailedException, RoleEntityAuthorizationService}
@@ -13,7 +13,7 @@ import fi.oph.kouta.logging.Logging
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 case class HakukohdeSearchParams(
     hakuOid: Option[HakuOid] = None,
@@ -66,10 +66,11 @@ class HakukohdeService(
     val organisaatioService: OrganisaatioService,
     hakuService: HakuService
 ) extends RoleEntityAuthorizationService[Hakukohde]
+    with MassService[HakukohdeOid, Hakukohde]
     with Logging {
 
-  def executor: ExecutionContext      = global
   override val roleEntity: RoleEntity = Role.Hakukohde
+  override val entityName: String     = "hakukohde"
 
   def getHakukohdeAuthorizeByHakukohderyhma(
       oid: HakukohdeOid
@@ -194,5 +195,4 @@ class HakukohdeService(
       authenticated: Authenticated
   ): Future[KoutaResponse[UpdateResponse]] =
     koutaClient.update("kouta-backend.hakukohde", KoutaHakukohdeRequest(authenticated, hakukohde), ifUnmodifiedSince)
-
 }

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/service/KoulutusService.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/service/KoulutusService.scala
@@ -1,10 +1,16 @@
 package fi.oph.kouta.external.service
 
-import fi.oph.kouta.domain.Amm
 import fi.oph.kouta.domain.oid.{GenericOid, KoulutusOid}
 import fi.oph.kouta.external.domain.{AmmatillinenKoulutusMetadata, Koulutus}
 import fi.oph.kouta.external.elasticsearch.{EPerusteClient, KoulutusClient}
-import fi.oph.kouta.external.kouta._
+import fi.oph.kouta.external.kouta.{
+  CasKoutaClient,
+  KoutaKoulutusRequest,
+  KoutaResponse,
+  OidResponse,
+  UpdateResponse,
+  UuidResponse
+}
 import fi.oph.kouta.logging.Logging
 import fi.oph.kouta.security.Role.Indexer
 import fi.oph.kouta.security.{Role, RoleEntity}
@@ -28,9 +34,11 @@ class KoulutusService(
     val koutaClient: CasKoutaClient,
     val organisaatioService: OrganisaatioService
 ) extends RoleEntityAuthorizationService[Koulutus]
+    with MassService[KoulutusOid, Koulutus]
     with Logging {
 
   override val roleEntity: RoleEntity = Role.Koulutus
+  override val entityName: String     = "koulutus"
 
   def get(oid: KoulutusOid)(implicit authenticated: Authenticated): Future[Koulutus] = {
     koulutusClient.getKoulutus(oid).flatMap { koulutus =>

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/service/MassService.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/service/MassService.scala
@@ -1,0 +1,88 @@
+package fi.oph.kouta.external.service
+
+import fi.oph.kouta.domain.oid.Oid
+import fi.oph.kouta.external.domain.PerustiedotWithOid
+import fi.oph.kouta.external.domain.enums.{MassResult, Operation}
+import fi.oph.kouta.external.kouta.{KoutaResponse, UpdateResponse}
+import fi.oph.kouta.external.service.MassService.tomorrowNoon
+import fi.oph.kouta.external.servlet.MassOperations
+import fi.oph.kouta.logging.Logging
+import fi.oph.kouta.servlet.Authenticated
+import fi.oph.kouta.util.Timer
+
+import java.time.{Instant, LocalDateTime, LocalTime, ZoneOffset}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import scala.util.{Failure, Success, Try}
+
+trait MassService[ID <: Oid, T <: PerustiedotWithOid[ID, T]] {
+  this: Logging =>
+
+  def create(entity: T)(implicit authenticated: Authenticated): Future[KoutaResponse[ID]]
+
+  def update(entity: T, ifUnmodifiedSince: Instant)(implicit
+      authenticated: Authenticated
+  ): Future[KoutaResponse[UpdateResponse]]
+
+  def entityName: String
+
+  def massImport(entities: List[T])(implicit authenticated: Authenticated): Future[List[MassResult]] = {
+    val duplicateOids = entities.flatMap(_.oid).groupBy(identity).collect { case (x, List(_, _, _*)) => x }
+    if (duplicateOids.nonEmpty) {
+      return Future.failed(DuplicateOidException(duplicateOids))
+    }
+    implicit val executor: ExecutionContextExecutor = MassOperations.executor
+    Future.traverse(entities)(k => Future(handleEntityInMass(k)))
+  }
+
+  private def handleEntityInMass(entity: T)(implicit authenticated: Authenticated): MassResult =
+    Timer.timed(s"Handling $entityName with oid ${entity.oid}") {
+      logger.info(s"Processing $entityName: ${entity.oid}")
+      entity.oid match {
+        case None      => handleCreate(entity)
+        case Some(oid) => handleUpdate(oid, entity)
+      }
+    }
+
+  private def handleCreate(entity: T)(implicit authenticated: Authenticated) =
+    Try(createBlocking(entity)) match {
+      case Failure(e) =>
+        logger.error(s"Mass create on $entityName threw an exception. Entity = $entity", e)
+        MassResult.Error(Operation.Create, entity.oid, entity.externalId, e)
+      case Success(Left((status, message))) =>
+        logger.warn(s"Creating $entityName failed. Response status = $status, message = $message. Entity = $entity")
+        MassResult.Failure(Operation.Create, entity.oid, entity.externalId, status, message)
+      case Success(Right(oid: ID)) =>
+        logger.info(s"Created $entityName $oid")
+        MassResult.CreateSuccess(oid, entity.externalId)
+    }
+
+  private def handleUpdate(oid: ID, entity: T)(implicit authenticated: Authenticated) =
+    Try(updateBlocking(entity, tomorrowNoon())) match {
+      case Failure(e) =>
+        logger.error(s"Mass update on $entityName threw an exception. Entity = $entity", e)
+        MassResult.Error(Operation.Update, entity.oid, entity.externalId, e)
+      case Success(Left((status, message))) =>
+        logger.warn(s"Updating $entityName failed. Response status = $status, message = $message. Entity = $entity")
+        MassResult.Failure(Operation.Update, entity.oid, entity.externalId, status, message)
+      case Success(Right(response)) =>
+        logger.info(s"Updated $entityName $oid")
+        MassResult.UpdateSuccess(oid, entity.externalId, response.updated)
+    }
+
+  private def createBlocking(entity: T)(implicit authenticated: Authenticated): KoutaResponse[ID] =
+    Await.result(create(entity), 60.seconds)
+
+  private def updateBlocking(entity: T, ifUnmodifiedSince: Instant)(implicit
+      authenticated: Authenticated
+  ): KoutaResponse[UpdateResponse] =
+    Await.result(update(entity, ifUnmodifiedSince), 60.seconds)
+}
+
+object MassService {
+  def tomorrowNoon(): Instant =
+    LocalDateTime.now().plusDays(1).`with`(LocalTime.of(12, 0, 0)).toInstant(ZoneOffset.UTC)
+}
+
+case class DuplicateOidException(duplicates: Iterable[Oid])
+    extends IllegalArgumentException(s"Pyynnössä oli monta kohdetta, joilla oli sama OID: ${duplicates.mkString(", ")}")

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/service/ToteutusService.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/service/ToteutusService.scala
@@ -16,9 +16,16 @@ import scala.concurrent.Future
 
 object ToteutusService extends ToteutusService(ToteutusClient, CasKoutaClient, OrganisaatioServiceImpl)
 
-class ToteutusService(toteutusClient: ToteutusClient, val koutaClient: CasKoutaClient, val organisaatioService: OrganisaatioService) extends RoleEntityAuthorizationService[Toteutus] with Logging {
+class ToteutusService(
+    toteutusClient: ToteutusClient,
+    val koutaClient: CasKoutaClient,
+    val organisaatioService: OrganisaatioService
+) extends RoleEntityAuthorizationService[Toteutus]
+    with MassService[ToteutusOid, Toteutus]
+    with Logging {
 
   override val roleEntity: RoleEntity = Role.Toteutus
+  override val entityName: String     = "toteutus"
 
   def get(oid: ToteutusOid)(implicit authenticated: Authenticated): Future[Toteutus] =
     toteutusClient

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/KoutaServlet.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/KoutaServlet.scala
@@ -27,7 +27,7 @@ trait KoutaServlet extends ScalatraServlet with KoutaJsonFormats with JacksonJso
     contentType = formats("json")
   }
 
-  protected def externalModifyEnabled(): Boolean =
+  protected def externalModifyEnabled: Boolean =
     KoutaConfigurationFactory.configuration.securityConfiguration.externalApiModifyEnabled
 
   protected def createLastModifiedHeader[E <: Perustiedot[_, E]](entity: E): Map[String, String] = {

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassHakukohdeServlet.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassHakukohdeServlet.scala
@@ -1,0 +1,69 @@
+package fi.oph.kouta.external.servlet
+
+import fi.oph.kouta.domain.oid.HakukohdeOid
+import fi.oph.kouta.external.domain.Hakukohde
+import fi.oph.kouta.external.service.{HakukohdeService, MassService}
+import fi.oph.kouta.external.swagger.SwaggerPaths.registerPath
+import fi.oph.kouta.servlet.Authenticated
+import org.scalatra.{ActionResult, AsyncResult, FutureSupport}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{ExecutionContext, Future}
+
+object MassHakukohdeServlet extends MassHakukohdeServlet(HakukohdeService)
+
+class MassHakukohdeServlet(
+    hakukohdeService: HakukohdeService
+) extends KoutaServlet
+    with CasAuthenticatedServlet
+    with FutureSupport {
+
+  override def executor: ExecutionContext = global
+
+  registerPath(
+    "/hakukohteet/",
+    """    put:
+      |      summary: Tallenna hakukohteet
+      |      operationId: Tallenna hakukohteet
+      |      description: Tallenna annettujen hakukohteiden tiedot.
+      |        Päivittää aiemmin lisätyt hakukohteet ja lisää puuttuvat. Jos hakukohteella on oid-kenttä,
+      |        sitä yritetään päivittää, muuten lisätä.
+      |
+      |        Rajapinta palauttaa lisäyksille tiedon sille annetusta oidista ja muutoksille tiedon,
+      |        päivitettiinkö hakukohdetta. Vastaukset ovat samassa järjestyksessä kuin pyynnön hakukohteet.
+      |
+      |        Huom! Rajapinnassa ei ole samanaikaisten muokkausten suojaa, eli jos joku on muokannut tietoja esim.
+      |        opintopolun käyttöliittymässä, nämä muutokset jyrätään.
+      |      tags:
+      |        - Hakukohde
+      |      requestBody:
+      |        description: Tallennettava hakukohde
+      |        required: true
+      |        content:
+      |          application/json:
+      |            schema:
+      |              type: array
+      |              items:
+      |                $ref: '#/components/schemas/Hakukohde'
+      |      responses:
+      |        '200':
+      |          description: Ok
+      |          content:
+      |            application/json:
+      |              schema:
+      |                $ref: '#/components/schemas/MassResult'
+      |""".stripMargin
+  )
+  put("/") {
+    if (externalModifyEnabled) {
+      implicit val authenticated: Authenticated = authenticate
+      new AsyncResult {
+        override def timeout: Duration = 15.minutes
+        override val is: Future[_]     = hakukohdeService.massImport(parsedBody.extract[List[Hakukohde]])
+      }
+    } else {
+      ActionResult(403, "Rajapinnan käyttö estetty tässä ympäristössä", Map.empty)
+    }
+  }
+}

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassKoulutusServlet.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassKoulutusServlet.scala
@@ -1,0 +1,76 @@
+package fi.oph.kouta.external.servlet
+
+import fi.oph.kouta.external.domain.Koulutus
+import fi.oph.kouta.external.service.KoulutusService
+import fi.oph.kouta.external.swagger.SwaggerPaths.registerPath
+import fi.oph.kouta.external.{KoutaConfiguration, KoutaConfigurationFactory}
+import fi.oph.kouta.servlet.Authenticated
+import org.scalatra.{ActionResult, AsyncResult, FutureSupport}
+
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+
+object MassOperations {
+  private val config: KoutaConfiguration = KoutaConfigurationFactory.configuration
+  private val numThreads = config.massOperationConfiguration.numThreds
+
+  val executor: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(numThreads))
+}
+
+object MassKoulutusServlet extends MassKoulutusServlet(KoulutusService)
+
+class MassKoulutusServlet(koulutusService: KoulutusService)
+    extends KoutaServlet
+    with CasAuthenticatedServlet
+    with FutureSupport {
+
+  override def executor: ExecutionContext = global
+
+  registerPath(
+    "/koulutukset/",
+    """    put:
+      |      summary: Tallenna koulutukset
+      |      operationId: Tallenna koulutukset
+      |      description: Tallenna annettujen koulutusten tiedot.
+      |        Päivittää aiemmin lisätyt koulutukset ja lisää puuttuvat. Jos koulutuksella on oid-kenttä,
+      |        sitä yritetään päivittää, muuten lisätä.
+      |
+      |        Rajapinta palauttaa lisäyksille tiedon sille annetusta oidista ja muutoksille tiedon,
+      |        päivitettiinkö koulutusta. Vastaukset ovat samassa järjestyksessä kuin pyynnön koulutukset.
+      |
+      |        Huom! Rajapinnassa ei ole samanaikaisten muokkausten suojaa, eli jos joku on muokannut tietoja esim.
+      |        opintopolun käyttöliittymässä, nämä muutokset jyrätään.
+      |      tags:
+      |        - Koulutus
+      |      requestBody:
+      |        description: Tallennettava koulutus
+      |        required: true
+      |        content:
+      |          application/json:
+      |            schema:
+      |              type: array
+      |              items:
+      |                $ref: '#/components/schemas/Koulutus'
+      |      responses:
+      |        '200':
+      |          description: Ok
+      |          content:
+      |            application/json:
+      |              schema:
+      |                $ref: '#/components/schemas/MassResult'
+      |""".stripMargin
+  )
+  put("/") {
+    if (externalModifyEnabled) {
+      implicit val authenticated: Authenticated = authenticate
+      new AsyncResult {
+        override def timeout: Duration = 15.minutes
+        override val is: Future[_] = koulutusService.massImport(parsedBody.extract[List[Koulutus]])
+      }
+    } else {
+      ActionResult(403, "Rajapinnan käyttö estetty tässä ympäristössä", Map.empty)
+    }
+  }
+}

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassToteutusServlet.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/servlet/MassToteutusServlet.scala
@@ -1,0 +1,68 @@
+package fi.oph.kouta.external.servlet
+
+import fi.oph.kouta.external.domain.Toteutus
+import fi.oph.kouta.external.service.ToteutusService
+import fi.oph.kouta.external.swagger.SwaggerPaths.registerPath
+import fi.oph.kouta.servlet.Authenticated
+import org.scalatra.{ActionResult, AsyncResult, FutureSupport}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{ExecutionContext, Future}
+
+object MassToteutusServlet extends MassToteutusServlet(ToteutusService)
+
+class MassToteutusServlet(
+    toteutusService: ToteutusService
+) extends KoutaServlet
+    with CasAuthenticatedServlet
+    with FutureSupport {
+
+  override def executor: ExecutionContext = global
+
+  registerPath(
+    "/toteutukset/",
+    """    put:
+      |      summary: Tallenna toteutukset
+      |      operationId: Tallenna toteutukset
+      |      description: Tallenna annettujen toteutusten tiedot.
+      |        Päivittää aiemmin lisätyt toteutukset ja lisää puuttuvat. Jos toteutuksella on oid-kenttä,
+      |        sitä yritetään päivittää, muuten lisätä.
+      |
+      |        Rajapinta palauttaa lisäyksille tiedon sille annetusta oidista ja muutoksille tiedon,
+      |        päivitettiinkö toteutusta. Vastaukset ovat samassa järjestyksessä kuin pyynnön toteutukset.
+      |
+      |        Huom! Rajapinnassa ei ole samanaikaisten muokkausten suojaa, eli jos joku on muokannut tietoja esim.
+      |        opintopolun käyttöliittymässä, nämä muutokset jyrätään.
+      |      tags:
+      |        - Toteutus
+      |      requestBody:
+      |        description: Tallennettava toteutus
+      |        required: true
+      |        content:
+      |          application/json:
+      |            schema:
+      |              type: array
+      |              items:
+      |                $ref: '#/components/schemas/Toteutus'
+      |      responses:
+      |        '200':
+      |          description: Ok
+      |          content:
+      |            application/json:
+      |              schema:
+      |                $ref: '#/components/schemas/MassResult'
+      |""".stripMargin
+  )
+  put("/") {
+    if (externalModifyEnabled) {
+      implicit val authenticated: Authenticated = authenticate
+      new AsyncResult {
+        override def timeout: Duration = 15.minutes
+        override val is: Future[_]     = toteutusService.massImport(parsedBody.extract[List[Toteutus]])
+      }
+    } else {
+      ActionResult(403, "Rajapinnan käyttö estetty tässä ympäristössä", Map.empty)
+    }
+  }
+}

--- a/kouta-external/src/main/scala/fi/oph/kouta/external/util/json.scala
+++ b/kouta-external/src/main/scala/fi/oph/kouta/external/util/json.scala
@@ -3,6 +3,7 @@ package fi.oph.kouta.external.util
 import fi.oph.kouta.domain._
 import fi.oph.kouta.domain.oid.HakuOid
 import fi.oph.kouta.external.domain._
+import fi.oph.kouta.external.domain.enums.Operation
 import fi.oph.kouta.external.domain.indexed._
 import fi.oph.kouta.util.{GenericKoutaFormats, GenericKoutaJsonFormats}
 import org.json4s.JsonAST.{JObject, JString}
@@ -24,7 +25,8 @@ sealed trait DefaultKoutaJsonFormats extends GenericKoutaFormats {
     valintatapaSisaltoSerializer,
     valintaperusteMetadataSerializer,
     valintaperusteMetadataIndexedSerializer,
-    stringSerializer(HakuOid)
+    stringSerializer(HakuOid),
+    stringSerializer(Operation.apply),
   )
 
   private def serializer[A: Manifest](deserializer: PartialFunction[JValue, A])(

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassHakukohdeSpec.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassHakukohdeSpec.scala
@@ -1,0 +1,123 @@
+package fi.oph.kouta.external.integration
+
+import fi.oph.kouta.domain.oid.HakukohdeOid
+import fi.oph.kouta.external.KoutaBackendMock
+import fi.oph.kouta.external.integration.fixture.{KoutaIntegrationSpec, MassHakukohdeFixture}
+import fi.oph.kouta.external.service.MassService
+import fi.oph.kouta.security.CasSession
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+class MassHakukohdeSpec extends KoutaBackendMock with MassHakukohdeFixture with KoutaIntegrationSpec {
+
+  val nonExistingSessionId: UUID = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
+
+  def mockCreate(
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None
+  ): Unit =
+    addCreateMock(
+      "hakukohde",
+      KoutaBackendConverters.convertHakukohde(hakukohde),
+      "kouta-backend.hakukohde",
+      responseString,
+      session,
+      responseStatus
+    )
+
+  def mockUpdate(
+      oid: HakukohdeOid,
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None
+  ): Unit =
+    addUpdateMock(
+      "hakukohde",
+      KoutaBackendConverters.convertHakukohde(hakukohde(oid)),
+      "kouta-backend.hakukohde",
+      Some(MassService.tomorrowNoon()),
+      session,
+      responseString,
+      responseStatus
+    )
+
+  def responseStringWithUpdated(updated: Boolean): String =
+    s"""{"updated": $updated}"""
+
+  def nonsenseResponseString: String =
+    """{"nonsense": true}"""
+
+  s"PUT /hakukohteet/" should "return 401 without a session" in {
+    put(nonExistingSessionId, 401, """{"error":"Unauthorized"}""")
+  }
+
+  it should "return 400 when called with duplicate oids" in {
+    put(List(hakukohde(hakukohdeOid), hakukohde(hakukohdeOid)), 400, s"""{"error":"Pyynnössä oli monta kohdetta, joilla oli sama OID: $hakukohdeOid"}""")
+  }
+
+  it should "create a new hakukohde when called without an oid" in {
+    mockCreate(responseStringWithOid(hakukohdeOid.s))
+
+    val result = put(List(hakukohde))
+
+    result shouldEqual parse(s"""[{"operation": "CREATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde"}]""")
+  }
+
+  it should "update an existing hakukohde when called with an oid" in {
+    mockUpdate(hakukohdeOid, responseStringWithUpdated(true))
+
+    val result = put(List(hakukohde(hakukohdeOid)))
+
+    result shouldEqual parse(s"""[{"operation": "UPDATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde", "updated": true}]""")
+  }
+
+  it should "create and update when called with both" in {
+    mockCreate(responseStringWithOid(hakukohdeOid.s))
+    mockUpdate(hakukohdeOid, responseStringWithUpdated(true))
+
+    val result = put(List(hakukohde, hakukohde(hakukohdeOid)))
+
+    result shouldEqual parse(s"""[
+                                |  {"operation": "CREATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde"},
+                                |  {"operation": "UPDATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde", "updated": true}
+                                |]""".stripMargin)
+  }
+
+  it should "respond with error when one operation fails" in {
+    mockCreate("""{"error": "Test error"}""", 403)
+    mockUpdate(hakukohdeOid, responseStringWithUpdated(true))
+
+    val result = put(List(hakukohde(hakukohdeOid), hakukohde))
+
+    result shouldEqual parse(s"""[
+                                |  {"operation": "UPDATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde", "updated": true},
+                                |  {"operation": "CREATE", "success": false, "externalId": "extHakukohde", "status": 403, "message": "{\\"error\\": \\"Test error\\"}"}
+                                |]""".stripMargin)
+  }
+
+  it should "continue when one operation throws an exception" in {
+    mockCreate(nonsenseResponseString)
+    mockUpdate(hakukohdeOid, responseStringWithUpdated(true))
+
+    val result = put(List(hakukohde, hakukohde(hakukohdeOid)))
+
+    result shouldEqual parse(s"""[
+                                |  {"operation": "CREATE", "success": false, "externalId": "extHakukohde", "exception": "scala.MatchError"},
+                                |  {"operation": "UPDATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde", "updated": true}
+                                |]""".stripMargin)
+  }
+
+  it should "returns earlier results after an exception" in {
+    mockCreate(responseStringWithOid(hakukohdeOid.s))
+    mockUpdate(hakukohdeOid, nonsenseResponseString)
+
+    val result = put(List(hakukohde, hakukohde(hakukohdeOid)))
+
+    result shouldEqual parse(s"""[
+                                |  {"operation": "CREATE", "success": true, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde"},
+                                |  {"operation": "UPDATE", "success": false, "oid": "${hakukohdeOid.s}", "externalId": "extHakukohde", "exception": "org.json4s.package.MappingException"}
+                                |]""".stripMargin)
+  }
+}

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassKoulutusSpec.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassKoulutusSpec.scala
@@ -1,0 +1,140 @@
+package fi.oph.kouta.external.integration
+
+import fi.oph.kouta.domain.oid.KoulutusOid
+import fi.oph.kouta.external.KoutaBackendMock
+import fi.oph.kouta.external.domain.Koulutus
+import fi.oph.kouta.external.integration.fixture.{KoutaIntegrationSpec, MassKoulutusFixture}
+import fi.oph.kouta.external.service.MassService
+import fi.oph.kouta.security.CasSession
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+class MassKoulutusSpec extends KoutaBackendMock with MassKoulutusFixture with KoutaIntegrationSpec {
+
+  val nonExistingSessionId: UUID = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
+
+  def mockCreate(
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None,
+      koulutus: Koulutus = koulutus
+  ): Unit =
+    addCreateMock(
+      "koulutus",
+      KoutaBackendConverters.convertKoulutus(koulutus),
+      "kouta-backend.koulutus",
+      responseString,
+      session,
+      responseStatus
+    )
+
+  def mockUpdate(
+      oid: KoulutusOid,
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None
+  ): Unit =
+    addUpdateMock(
+      "koulutus",
+      KoutaBackendConverters.convertKoulutus(koulutus(oid)),
+      "kouta-backend.koulutus",
+      Some(MassService.tomorrowNoon()),
+      session,
+      responseString,
+      responseStatus
+    )
+
+  def responseStringWithUpdated(updated: Boolean): String =
+    s"""{"updated": $updated}"""
+
+  def nonsenseResponseString: String =
+    """{"nonsense": true}"""
+
+  s"PUT /koulutukset/" should "return 401 without a session" in {
+    put(nonExistingSessionId, 401, """{"error":"Unauthorized"}""")
+  }
+
+  it should "return 400 when called with duplicate oids" in {
+    put(List(koulutus(koulutusOid), koulutus(koulutusOid)), 400, s"""{"error":"Pyynnössä oli monta kohdetta, joilla oli sama OID: $koulutusOid"}""")
+  }
+
+  it should "create a new koulutus when called without an oid" in {
+    mockCreate(responseStringWithOid(koulutusOid.s))
+
+    val result = put(List(koulutus))
+
+    result shouldEqual parse(
+      s"""[{"operation": "CREATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1"}]"""
+    )
+  }
+
+  it should "create a new koulutus when called without an oid and without external ID" in {
+    val koulutusWithoutExternalId = koulutus.copy(externalId = None)
+    mockCreate(responseStringWithOid(koulutusOid.s), koulutus = koulutusWithoutExternalId)
+
+    val result = put(List(koulutusWithoutExternalId))
+
+    result shouldEqual parse(s"""[{"operation": "CREATE", "success": true, "oid": "${koulutusOid.s}"}]""")
+  }
+
+  it should "update an existing koulutus when called with an oid" in {
+    mockUpdate(koulutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(koulutus(koulutusOid)))
+
+    result shouldEqual parse(s"""[{"operation": "UPDATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1", "updated": true}]""")
+  }
+
+  it should "create and update when called with both" in {
+    mockCreate(responseStringWithOid(koulutusOid.s))
+    mockUpdate(koulutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(koulutus, koulutus(koulutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1"},
+         |  {"operation": "UPDATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1", "updated": true}
+         |]""".stripMargin)
+  }
+
+  it should "respond with error when one operation fails" in {
+    mockCreate("""{"error": "Test error"}""", 403)
+    mockUpdate(koulutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(koulutus(koulutusOid), koulutus))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "UPDATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1", "updated": true},
+         |  {"operation": "CREATE", "success": false, "externalId": "extKoulutus1", "status": 403, "message": "{\\"error\\": \\"Test error\\"}"}
+         |]""".stripMargin)
+  }
+
+  it should "continue when one operation throws an exception" in {
+    mockCreate(nonsenseResponseString)
+    mockUpdate(koulutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(koulutus, koulutus(koulutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": false, "externalId": "extKoulutus1", "exception": "scala.MatchError"},
+         |  {"operation": "UPDATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1", "updated": true}
+         |]""".stripMargin)
+  }
+
+  it should "returns earlier results after an exception" in {
+    mockCreate(responseStringWithOid(koulutusOid.s))
+    mockUpdate(koulutusOid, nonsenseResponseString)
+
+    val result = put(List(koulutus, koulutus(koulutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": true, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1"},
+         |  {"operation": "UPDATE", "success": false, "oid": "${koulutusOid.s}", "externalId": "extKoulutus1", "exception": "org.json4s.package.MappingException"}
+         |]""".stripMargin)
+  }
+}

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassToteutusSpec.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/MassToteutusSpec.scala
@@ -1,0 +1,127 @@
+package fi.oph.kouta.external.integration
+
+import fi.oph.kouta.domain.oid.ToteutusOid
+import fi.oph.kouta.external.KoutaBackendMock
+import fi.oph.kouta.external.integration.fixture.{KoutaIntegrationSpec, MassToteutusFixture}
+import fi.oph.kouta.external.service.MassService
+import fi.oph.kouta.security.CasSession
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+class MassToteutusSpec extends KoutaBackendMock with MassToteutusFixture with KoutaIntegrationSpec {
+
+  val nonExistingSessionId: UUID = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
+
+  def mockCreate(
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None
+  ): Unit =
+    addCreateMock(
+      "toteutus",
+      KoutaBackendConverters.convertToteutus(toteutus),
+      "kouta-backend.toteutus",
+      responseString,
+      session,
+      responseStatus
+    )
+
+  def mockUpdate(
+      oid: ToteutusOid,
+      responseString: String,
+      responseStatus: Int = 200,
+      session: Option[(UUID, CasSession)] = None
+  ): Unit =
+    addUpdateMock(
+      "toteutus",
+      KoutaBackendConverters.convertToteutus(toteutus(oid)),
+      "kouta-backend.toteutus",
+      Some(MassService.tomorrowNoon()),
+      session,
+      responseString,
+      responseStatus
+    )
+
+  def responseStringWithUpdated(updated: Boolean): String =
+    s"""{"updated": $updated}"""
+
+  def nonsenseResponseString: String =
+    """{"nonsense": true}"""
+
+  s"PUT /toteutukset/" should "return 401 without a session" in {
+    put(nonExistingSessionId, 401, """{"error":"Unauthorized"}""")
+  }
+
+  it should "return 400 when called with duplicate oids" in {
+    put(List(toteutus(toteutusOid), toteutus(toteutusOid)), 400, s"""{"error":"Pyynnössä oli monta kohdetta, joilla oli sama OID: $toteutusOid"}""")
+  }
+
+  it should "create a new toteutus when called without an oid" in {
+    mockCreate(responseStringWithOid(toteutusOid.s))
+
+    val result = put(List(toteutus))
+
+    result shouldEqual parse(s"""[{"operation": "CREATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1"}]""")
+  }
+
+  it should "update an existing toteutus when called with an oid" in {
+    mockUpdate(toteutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(toteutus(toteutusOid)))
+
+    result shouldEqual parse(s"""[{"operation": "UPDATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1", "updated": true}]""")
+  }
+
+  it should "create and update when called with both" in {
+    mockCreate(responseStringWithOid(toteutusOid.s))
+    mockUpdate(toteutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(toteutus, toteutus(toteutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1"},
+         |  {"operation": "UPDATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1", "updated": true}
+         |]""".stripMargin)
+  }
+
+  it should "respond with error when one operation fails" in {
+    mockCreate("""{"error": "Test error"}""", 403)
+    mockUpdate(toteutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(toteutus(toteutusOid), toteutus))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "UPDATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1", "updated": true},
+         |  {"operation": "CREATE", "success": false, "externalId": "extToteutus1", "status": 403, "message": "{\\"error\\": \\"Test error\\"}"}
+         |]""".stripMargin)
+  }
+
+  it should "continue when one operation throws an exception" in {
+    mockCreate(nonsenseResponseString)
+    mockUpdate(toteutusOid, responseStringWithUpdated(true))
+
+    val result = put(List(toteutus, toteutus(toteutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": false, "externalId": "extToteutus1", "exception": "scala.MatchError"},
+         |  {"operation": "UPDATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1", "updated": true}
+         |]""".stripMargin)
+  }
+
+  it should "returns earlier results after an exception" in {
+    mockCreate(responseStringWithOid(toteutusOid.s))
+    mockUpdate(toteutusOid, nonsenseResponseString)
+
+    val result = put(List(toteutus, toteutus(toteutusOid)))
+
+    result shouldEqual parse(
+      s"""[
+         |  {"operation": "CREATE", "success": true, "oid": "${toteutusOid.s}", "externalId": "extToteutus1"},
+         |  {"operation": "UPDATE", "success": false, "oid": "${toteutusOid.s}", "externalId": "extToteutus1", "exception": "org.json4s.package.MappingException"}
+         |]""".stripMargin)
+  }
+}

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/ToteutusSpec.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/ToteutusSpec.scala
@@ -4,7 +4,7 @@ import fi.oph.kouta.TestOids._
 import fi.oph.kouta.domain.oid.{KoulutusOid, OrganisaatioOid, ToteutusOid}
 import fi.oph.kouta.external.KoutaBackendMock
 import fi.oph.kouta.external.domain.Toteutus
-import fi.oph.kouta.external.integration.fixture.{AccessControlSpec, KoulutusFixture, ToteutusFixture}
+import fi.oph.kouta.external.integration.fixture.{AccessControlSpec, ToteutusFixture}
 import fi.oph.kouta.security.{CasSession, Role}
 
 import java.time.Instant

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassHakukohdeFixture.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassHakukohdeFixture.scala
@@ -1,0 +1,59 @@
+package fi.oph.kouta.external.integration.fixture
+
+import fi.oph.kouta.domain.oid.HakukohdeOid
+import fi.oph.kouta.external.TestData.JulkaistuHakukohde
+import fi.oph.kouta.external.domain.Hakukohde
+import fi.oph.kouta.external.elasticsearch.{HakuClient, HakukohdeClient}
+import fi.oph.kouta.external.service.{HakuService, HakukohdeService, HakukohderyhmaService, OrganisaatioServiceImpl}
+import fi.oph.kouta.external.servlet.MassHakukohdeServlet
+import fi.oph.kouta.external.{MockHakukohderyhmaClient, MockKoutaClient, TempElasticClient}
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+trait MassHakukohdeFixture extends AccessControlSpec {
+  this: KoutaIntegrationSpec =>
+
+  val Path = "/hakukohteet"
+
+  val hakukohde: Hakukohde       = JulkaistuHakukohde
+  val hakukohdeOid: HakukohdeOid = HakukohdeOid("1.2.246.562.17.0000111")
+
+  def hakukohde(oid: HakukohdeOid): Hakukohde =
+    hakukohde.copy(oid = Some(oid))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val organisaatioService  = new OrganisaatioServiceImpl(urlProperties.get)
+    val hakukohderyhmaClient = new MockHakukohderyhmaClient(urlProperties.get)
+
+    val hakuService = new HakuService(
+      new HakuClient(TempElasticClient.client, TempElasticClient.clientJava),
+      new MockKoutaClient(urlProperties.get),
+      organisaatioService
+    )
+    val hakukohderyhmaService = new HakukohderyhmaService(hakukohderyhmaClient, organisaatioService)
+    val hakukohdeService = new HakukohdeService(
+      new HakukohdeClient(TempElasticClient.client, TempElasticClient.clientJava),
+      hakukohderyhmaService,
+      new MockKoutaClient(urlProperties.get),
+      organisaatioService,
+      hakuService
+    )
+    addServlet(new MassHakukohdeServlet(hakukohdeService), Path)
+  }
+
+  def parseResult(result: String): JValue =
+    parse(result)
+
+  def put(sessionId: UUID, expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, List.empty, sessionId, expectedStatus, expectedBody)
+
+  def put(hakukohteet: List[Hakukohde]): JValue =
+    create(Path, hakukohteet, defaultSessionId, parseResult)
+
+  def put(hakukohteet: List[Hakukohde], expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, hakukohteet, defaultSessionId, expectedStatus, expectedBody)
+
+}

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassKoulutusFixture.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassKoulutusFixture.scala
@@ -1,0 +1,49 @@
+package fi.oph.kouta.external.integration.fixture
+
+import fi.oph.kouta.domain.oid.KoulutusOid
+import fi.oph.kouta.external.TestData.AmmKoulutus
+import fi.oph.kouta.external.domain.Koulutus
+import fi.oph.kouta.external.elasticsearch.{EPerusteClient, KoulutusClient}
+import fi.oph.kouta.external.service.{KoulutusService, OrganisaatioServiceImpl}
+import fi.oph.kouta.external.servlet.MassKoulutusServlet
+import fi.oph.kouta.external.{MockKoutaClient, TempElasticClient}
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+trait MassKoulutusFixture extends AccessControlSpec {
+  this: KoutaIntegrationSpec =>
+
+  val Path = "/koulutukset/"
+
+  val koulutus: Koulutus       = AmmKoulutus
+  val koulutusOid: KoulutusOid = KoulutusOid("1.2.246.562.13.123")
+
+  def koulutus(oid: KoulutusOid): Koulutus =
+    koulutus.copy(oid = Some(oid))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val koulutusService = new KoulutusService(
+      new KoulutusClient(TempElasticClient.client, TempElasticClient.clientJava),
+      new EPerusteClient(TempElasticClient.client, TempElasticClient.clientJava),
+      new MockKoutaClient(urlProperties.get),
+      new OrganisaatioServiceImpl(urlProperties.get)
+    )
+    addServlet(new MassKoulutusServlet(koulutusService), Path)
+  }
+
+  def parseResult(result: String): JValue =
+    parse(result)
+
+  def put(sessionId: UUID, expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, List.empty, sessionId, expectedStatus, expectedBody)
+
+  def put(koulutukset: List[Koulutus]): JValue =
+    create(Path, koulutukset, defaultSessionId, parseResult)
+
+  def put(koulutukset: List[Koulutus], expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, koulutukset, defaultSessionId, expectedStatus, expectedBody)
+
+}

--- a/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassToteutusFixture.scala
+++ b/kouta-external/src/test/scala/fi/oph/kouta/external/integration/fixture/MassToteutusFixture.scala
@@ -1,0 +1,47 @@
+package fi.oph.kouta.external.integration.fixture
+
+import fi.oph.kouta.domain.oid.ToteutusOid
+import fi.oph.kouta.external.TestData.AmmToteutus
+import fi.oph.kouta.external.domain.Toteutus
+import fi.oph.kouta.external.elasticsearch.ToteutusClient
+import fi.oph.kouta.external.service.{OrganisaatioServiceImpl, ToteutusService}
+import fi.oph.kouta.external.servlet.MassToteutusServlet
+import fi.oph.kouta.external.{MockKoutaClient, TempElasticClient}
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods.parse
+
+import java.util.UUID
+
+trait MassToteutusFixture extends AccessControlSpec {
+  this: KoutaIntegrationSpec =>
+
+  val Path = "/toteutukset/"
+
+  val toteutus: Toteutus       = AmmToteutus
+  val toteutusOid: ToteutusOid = ToteutusOid("1.2.246.562.17.0000111")
+
+  def toteutus(oid: ToteutusOid): Toteutus =
+    toteutus.copy(oid = Some(oid))
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val toteutusService = new ToteutusService(
+      new ToteutusClient(TempElasticClient.client, TempElasticClient.clientJava),
+      new MockKoutaClient(urlProperties.get),
+      new OrganisaatioServiceImpl(urlProperties.get)
+    )
+    addServlet(new MassToteutusServlet(toteutusService), Path)
+  }
+
+  def parseResult(result: String): JValue =
+    parse(result)
+
+  def put(sessionId: UUID, expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, List.empty, sessionId, expectedStatus, expectedBody)
+
+  def put(toteutukset: List[Toteutus]): JValue =
+    create(Path, toteutukset, defaultSessionId, parseResult)
+
+  def put(toteutukset: List[Toteutus], expectedStatus: Int, expectedBody: String): Unit =
+    create(Path, toteutukset, defaultSessionId, expectedStatus, expectedBody)
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <scalactic.version>3.1.1</scalactic.version>
 
         <!-- Plugin properties -->
-        <enforce.java.version>[11,)</enforce.java.version>
+        <enforce.java.version>[21,)</enforce.java.version>
 
         <plugin.scala-maven-plugin.version>4.8.0</plugin.scala-maven-plugin.version>
         <plugin.maven-enforcer-plugin.version>3.2.1</plugin.maven-enforcer-plugin.version>


### PR DESCRIPTION
Lisätään rajapinnat toteutusten ja hakukohteiden massatuonnille.

Uusi rajapinta jakaa sekä swagger-määrittelyjä että service-koodia aiemman koulutusten massarajapinnan kanssa.