### PR TITLE
OY-5447 Päivitetään Europass vastaamaan ELM versiota 3.3

### DIFF
--- a/europass-publisher/README.md
+++ b/europass-publisher/README.md
@@ -19,6 +19,8 @@ XML-skeeman dokumentaatio:
    https://europa.eu/europass/elm-browser/documentation/xsd/ap/loq/documentation/loq_xsd.html
  - Vaaditut kentät:
    https://europass.europa.eu/en/stakeholders/qdr/publishdata#8705
+ - Itse skeematiedosto löytyy (LOQ schemata):
+   https://europass.europa.eu/en/stakeholders/qdr/documentlibrary
 
 Testien ajaminen
 ----------------
@@ -90,4 +92,3 @@ Lopputulos näkyy (QA-ympäristössä) AWS-konsolissa paikassa osoitteessa
 https://eu-west-1.console.aws.amazon.com/s3/object/europass-publish-pallero?region=eu-west-1&prefix=europass-export-1.xml
 ja julkisesti osoitteessa
 https://europass-publish-pallero.s3.eu-west-1.amazonaws.com/europass-export-1.xml
-

--- a/europass-publisher/pom.xml
+++ b/europass-publisher/pom.xml
@@ -85,6 +85,13 @@
             <artifactId>scalatra-json_2.12</artifactId>
         </dependency>
 
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.22.1</version>
+        </dependency>
+
         <!-- utilities -->
         <dependency>
             <groupId>fi.vm.sade.dokumenttipalvelu</groupId>

--- a/europass-publisher/src/main/resources/xsd/cv/loq_individuals.xsd
+++ b/europass-publisher/src/main/resources/xsd/cv/loq_individuals.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://data.europa.eu/snb/model/ap/loq-constraints/"
+<xs:schema xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    targetNamespace="http://data.europa.eu/snb/model/ap/loq-constraints/">
+    targetNamespace="http://data.europa.eu/snb/model/application-profile/loq-constraints/">
 
     <xs:simpleType name="SubjectTypeCodeEnumType">
         <xs:annotation>

--- a/europass-publisher/src/main/resources/xsd/cv/loq_individuals.xsd
+++ b/europass-publisher/src/main/resources/xsd/cv/loq_individuals.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
+<xs:schema xmlns="http://data.europa.eu/snb/model/application-profile/ams-constraints/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     targetNamespace="http://data.europa.eu/snb/model/application-profile/loq-constraints/">
 

--- a/europass-publisher/src/main/resources/xsd/loq.xsd
+++ b/europass-publisher/src/main/resources/xsd/loq.xsd
@@ -34,7 +34,7 @@
            xmlns:cp="http://data.europa.eu/snb/education-credit/25831c2"
            xmlns:curr="http://publications.europa.eu/resource/authority/currency"
            targetNamespace="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
-           elementFormDefault="qualified" version="3.1.0">
+           elementFormDefault="qualified" version="3.3.1">
 
    <xs:include schemaLocation="cv/loq_individuals.xsd"/>
 
@@ -375,7 +375,7 @@
    <xs:element name="learningAssessmentSpecification" type="LearningAssessmentSpecificationType"/>
    <xs:element name="learningEntitlementSpecification" type="LearningEntitlementSpecificationType"/>
    <xs:element name="learningOpportunity" type="LearningOpportunityType"/>
-   <xs:element name="emailAddress" type="EmailAddressType"/>
+   <xs:element name="emailAddress" type="MailboxType"/>
    <xs:element name="phone" type="PhoneType"/>
    <xs:element name="priceDetail" type="PriceDetailType"/>
    <xs:element name="qualification" type="QualificationType"/>
@@ -1045,7 +1045,7 @@
                      <xs:documentation>Specific entry requirements or prerequisites of individuals for which this specification is designed to start this learning opportunity.</xs:documentation>
                   </xs:annotation>
                </xs:element>
-               <xs:element maxOccurs="unbounded" minOccurs="1" name="learningOutcome" type="IdReferenceType">
+               <xs:element maxOccurs="unbounded" minOccurs="0" name="learningOutcome" type="IdReferenceType">
                   <xs:annotation>
                      <xs:documentation>An individual (expected) learning outcome of the learning specification. It MUST refer to an existing 'LearningOutcome'-record in the 'learningOutcomeReferences'-section.</xs:documentation>
                   </xs:annotation>
@@ -1543,9 +1543,9 @@
       </xs:complexContent>
    </xs:complexType>
 
-   <xs:complexType name="EmailAddressType">
+   <xs:complexType name="MailboxType">
       <xs:annotation>
-         <xs:documentation>An e-mail address.</xs:documentation>
+         <xs:documentation>A mailbox.</xs:documentation>
       </xs:annotation>
       <xs:simpleContent>
          <xs:extension base="xs:anyURI"/>
@@ -1613,7 +1613,7 @@
                <xs:documentation>The format of the note.</xs:documentation>
             </xs:annotation>
          </xs:element>
-         <xs:element ref="noteLiteral">
+         <xs:element ref="noteLiteral" minOccurs="1" maxOccurs="unbounded">
             <xs:annotation>
                <xs:documentation>The textual content of the note.</xs:documentation>
             </xs:annotation>
@@ -2014,7 +2014,7 @@
             </xs:annotation>
          </xs:element>
       </xs:sequence>
-      <xs:attribute name="xsdVersion" use="optional" default="3.1.0">
+      <xs:attribute name="xsdVersion" use="optional" default="3.3.1">
          <xs:annotation>
             <xs:documentation>used xsd version</xs:documentation>
          </xs:annotation>
@@ -2022,6 +2022,7 @@
             <xs:restriction base="xs:token">
                <xs:enumeration value="3.0.0"/>
                <xs:enumeration value="3.1.0"/>
+               <xs:enumeration value="3.3.1"/>
             </xs:restriction>
          </xs:simpleType>
       </xs:attribute>

--- a/europass-publisher/src/main/resources/xsd/loq.xsd
+++ b/europass-publisher/src/main/resources/xsd/loq.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://data.europa.eu/snb/model/ap/loq-constraints/"
-           xmlns:loq="http://data.europa.eu/snb/model/ap/loq-constraints/"
+<xs:schema xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
+           xmlns:loq="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
            xmlns:adms="http://www.w3.org/ns/adms#"
            xmlns:dc="http://purl.org/dc/terms/"
-           xmlns:elm="http://data.europa.eu/snb/model/elm/"
+           xmlns:elm="http://data.europa.eu/snb/model/ontology/"
            xmlns:foaf="http://xmlns.com/foaf/0.1/"
            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
            xmlns:locn="http://www.w3.org/ns/locn#"
@@ -33,7 +33,7 @@
            xmlns:sched="http://data.europa.eu/snb/learning-schedule/25831c2"
            xmlns:cp="http://data.europa.eu/snb/education-credit/25831c2"
            xmlns:curr="http://publications.europa.eu/resource/authority/currency"
-           targetNamespace="http://data.europa.eu/snb/model/ap/loq-constraints/"
+           targetNamespace="http://data.europa.eu/snb/model/application-profile/loq-constraints/"
            elementFormDefault="qualified" version="3.1.0">
 
    <xs:include schemaLocation="cv/loq_individuals.xsd"/>

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElmValidation.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/ElmValidation.scala
@@ -1,10 +1,9 @@
 package fi.oph.kouta.europass
 
-import scala.io.Source
 import javax.xml.XMLConstants
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{Schema, SchemaFactory, Validator}
-// import org.xml.sax.{ErrorHandler, SAXParseException}
+import scala.io.Source
 
 object ElmValidation {
 
@@ -13,9 +12,8 @@ object ElmValidation {
   val loqSchema: Schema = schemaFactory.newSchema(loqSchemaURI)
   val loqValidator: Validator = loqSchema.newValidator()
 
-  def validateXml(xmlFile: String): Boolean = {
+  def validateXml(xmlFile: String): Unit = {
     loqValidator.validate(new StreamSource(Source.fromFile(xmlFile).bufferedReader))
-    return true
   }
 
 }

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -1,29 +1,24 @@
 package fi.oph.kouta.europass
 
-import scala.xml._
+import scala.xml.Elem
 import org.json4s._
 import fi.oph.kouta.domain.Julkaistu
-import fi.oph.kouta.external.domain.indexed.{
-  AmmatillinenKoulutusMetadataIndexed,
-  ErikoislaakariKoulutusMetadataIndexed,
-  KoodiUri, KorkeakoulutusKoulutusMetadataIndexed,
-  KoulutuksenAlkamiskausiIndexed,
-  KoulutusIndexed,
-  OpetusIndexed,
-  OppilaitosIndexed,
-  Organisaatio,
-  ToteutusIndexed,
-  TutkintoNimike
-}
+import fi.oph.kouta.domain.oid.Oid
+import fi.oph.kouta.external.domain.indexed.{AmmatillinenKoulutusMetadataIndexed, ErikoislaakariKoulutusMetadataIndexed, KoodiUri, KorkeakoulutusKoulutusMetadataIndexed, KoulutuksenAlkamiskausiIndexed, KoulutusIndexed, OpetusIndexed, OppilaitosIndexed, Organisaatio, ToteutusIndexed, TutkintoNimike}
 import fi.oph.kouta.external.domain.Kielistetty
 import fi.oph.kouta.logging.Logging
 import org.jsoup.Jsoup
-import org.jsoup.safety.{Cleaner, Safelist}
+import org.jsoup.nodes.{Document, TextNode}
+import org.jsoup.safety.Safelist
 
 class EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
 
-  private val safelist = Safelist.relaxed().removeTags("a")
+  private val safelist = Safelist.none()
+    .addTags("h1", "h2", "h3", "h4", "h5", "h6", "p", "strong", "b", "em", "i", "code", "ul", "ol", "li", "br", "hr", "u", "address", "section", "small", "sub", "sup")
+    .addAttributes("li", "value")
+    .addAttributes("ol", "start", "type")
+    .addAttributes(":all", "style")
 
   lazy val toteutusExtras = EuropassConfiguration.config.getBoolean(
     "europass-publisher.publishing.toteutus-extra-fields"
@@ -99,7 +94,7 @@ class EuropassConversion extends Logging {
     toteutus.metadata.map(_.kuvaus) match {
       case Some(kuvaukset: Kielistetty) if toteutusExtras =>
         kuvaukset.keys.map { lang =>
-          <description language={lang.name}>{cleanHtml(kuvaukset(lang))}</description>
+          <description language={lang.name}>{cleanHtml(kuvaukset(lang), toteutus.oid)}</description>
         }.toList
       case _ => List()
     }
@@ -143,7 +138,7 @@ class EuropassConversion extends Logging {
         .take(1)  // No way to express language alternatives so we just pick a random one
         .map { case (lang, desc) =>
           <scheduleInformation>
-            <noteLiteral language={lang.name}>{cleanHtml(desc)}</noteLiteral>
+            <noteLiteral language={lang.name}>{cleanHtml(desc, toteutus.oid)}</noteLiteral>
           </scheduleInformation>
         }
   }
@@ -242,9 +237,9 @@ class EuropassConversion extends Logging {
   def toteutusToKoulutusDependents(toteutus: ToteutusIndexed): Iterable[String] =
     toteutus.koulutusOid.map(_.toString)
 
-  def kielistettyAsNoteLiterals(content: Kielistetty): Iterable[Elem] =
+  def kielistettyAsNoteLiterals(content: Kielistetty, oid: Option[Oid]): Iterable[Elem] =
     content.keys.take(1)  // No way to express language alternatives so we just pick a random one
-      .map{lang => <noteLiteral language={lang.name}>{cleanHtml(content(lang))}</noteLiteral>}
+      .map{lang => <noteLiteral language={lang.name}>{cleanHtml(content(lang), oid)}</noteLiteral>}
 
   def tarjoajaAsElmXml(tarjoaja: OppilaitosIndexed): Elem = {
     val nimet = tarjoaja.nimi.getOrElse(Map())
@@ -255,11 +250,10 @@ class EuropassConversion extends Logging {
       {nimet.keys.map{lang =>
         <legalName language={lang.name}>{nimet(lang)}</legalName>}}
       {
-        if (esittely.isEmpty) {
+        if (esittely.isEmpty)
           List()
-        } else {
-          <additionalNote>{kielistettyAsNoteLiterals(esittely)}</additionalNote>
-        }
+        else
+          <additionalNote>{kielistettyAsNoteLiterals(esittely, Some(tarjoaja.oid))}</additionalNote>
       }
       <location idref={sijaintiUrl(oid)}/>
     </organisation>
@@ -278,7 +272,7 @@ class EuropassConversion extends Logging {
           if (osoite.isEmpty) {
             List()
           } else {
-            <fullAddress>{kielistettyAsNoteLiterals(osoite)}</fullAddress>
+            <fullAddress>{kielistettyAsNoteLiterals(osoite, Some(tarjoaja.oid))}</fullAddress>
           }
         }
         <countryCode uri="http://publications.europa.eu/resource/authority/country/FIN"/>
@@ -289,8 +283,48 @@ class EuropassConversion extends Logging {
   def toteutusToTarjoajaDependents(toteutus: ToteutusIndexed): Iterable[Organisaatio] =
     toteutus.tarjoajat
 
-  private def cleanHtml(s: String): String = {
-    Jsoup.clean(s, safelist)
+  /**
+   * NoteLiteral ja description -kentät validoidaan Europassin päässä SHACL-muodolla HtmlWhitelistLiteralShape,
+   * joka rajaa käytettävät HTML-elementit seuraaviin: h1–h6, p, strong/b, em/i, code, ul, ol, li, br, hr, u, address, section, small, sub, sup.
+   *
+   * Tässä funktiossa poistetaan kaikki tagit, jotka rikkovat tätä ehtoa. Ehtoa rikkovat tapaukset logitetaan.
+   *
+   * Dokumentaatio tuosta muodosta löytyy EU:n julkaisutoimistolta:
+   * https://op.europa.eu/fi/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/snb-model
+   * Tiedosto on LOQ-constraints.rdf
+   */
+  def cleanHtml(s: String, oid: Option[Oid]): String = {
+    val html = Jsoup.parse(s)
+
+    removeLinks(html)
+
+    val htmlString = html.body().html().trim
+    if (!Jsoup.isValid(htmlString, safelist)) {
+      logger.warn(s"Kohteella ${oid.getOrElse("?")} on tietoja, jotka rikkovat Europassin HTML-tagien validointisääntöjä: ${htmlString.replace("\n", " ")}")
+    }
+
+    Jsoup.clean(htmlString, safelist)
+  }
+
+  private def removeLinks(html: Document): Unit = {
+    val links = html.select("a[href]")
+    links.forEach { element =>
+      val url = element.attr("href")
+        .replace("mailto:", "") // mailto:-linkit pelkiksi osoitteiksi
+        .replace("tel:", "") // tel: linkit pelkiksi puhelinnumeroiksi
+        .replaceAll("^about:blank", "") // poistetaan about:blank linkit
+        .replaceAll("^#(\\w|_)+", "") // poistetaan sivun sisäiset linkit
+      val text = element.text()
+
+      val textNode = if (text.replaceAll("\\s", "") == url.replaceAll("\\s", "")) {
+        new TextNode(s"$url")
+      } else if (url == "") {
+        new TextNode(text)
+      } else {
+        new TextNode(s"$text ($url)")
+      }
+      element.replaceWith(textNode)
+    }
   }
 }
 

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -23,7 +23,7 @@ import org.jsoup.safety.{Cleaner, Safelist}
 class EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
 
-  val cleaner = new Cleaner(Safelist.none)
+  private val cleaner = new Cleaner(Safelist.relaxed())
 
   lazy val toteutusExtras = EuropassConfiguration.config.getBoolean(
     "europass-publisher.publishing.toteutus-extra-fields"
@@ -290,8 +290,7 @@ class EuropassConversion extends Logging {
     toteutus.tarjoajat
 
   private def cleanHtml(s: String): String = {
-    val document: org.jsoup.nodes.Document = cleaner.clean(Jsoup.parse(s))
-    document.text
+    Jsoup.clean(s, Safelist.relaxed())
   }
 }
 

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -23,7 +23,7 @@ import org.jsoup.safety.{Cleaner, Safelist}
 class EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
 
-  private val cleaner = new Cleaner(Safelist.relaxed())
+  private val safelist = Safelist.relaxed().removeTags("a")
 
   lazy val toteutusExtras = EuropassConfiguration.config.getBoolean(
     "europass-publisher.publishing.toteutus-extra-fields"
@@ -290,7 +290,7 @@ class EuropassConversion extends Logging {
     toteutus.tarjoajat
 
   private def cleanHtml(s: String): String = {
-    Jsoup.clean(s, Safelist.relaxed())
+    Jsoup.clean(s, safelist)
   }
 }
 

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -2,25 +2,28 @@ package fi.oph.kouta.europass
 
 import scala.xml._
 import org.json4s._
-import fi.oph.kouta.domain.{Julkaisutila, Julkaistu}
+import fi.oph.kouta.domain.Julkaistu
 import fi.oph.kouta.external.domain.indexed.{
-  KoodiUri,
+  AmmatillinenKoulutusMetadataIndexed,
+  ErikoislaakariKoulutusMetadataIndexed,
+  KoodiUri, KorkeakoulutusKoulutusMetadataIndexed,
+  KoulutuksenAlkamiskausiIndexed,
   KoulutusIndexed,
-  ToteutusIndexed,
   OpetusIndexed,
-  TutkintoNimike,
   OppilaitosIndexed,
   Organisaatio,
-  AmmatillinenKoulutusMetadataIndexed,
-  KorkeakoulutusKoulutusMetadataIndexed,
-  ErikoislaakariKoulutusMetadataIndexed,
-  KoulutuksenAlkamiskausiIndexed
+  ToteutusIndexed,
+  TutkintoNimike
 }
 import fi.oph.kouta.external.domain.Kielistetty
 import fi.oph.kouta.logging.Logging
+import org.jsoup.Jsoup
+import org.jsoup.safety.{Cleaner, Safelist}
 
 class EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
+
+  val cleaner = new Cleaner(Safelist.none)
 
   lazy val toteutusExtras = EuropassConfiguration.config.getBoolean(
     "europass-publisher.publishing.toteutus-extra-fields"
@@ -95,8 +98,8 @@ class EuropassConversion extends Logging {
   def toteutuksenKuvausAsElmXml(toteutus: ToteutusIndexed): Seq[Elem] =
     toteutus.metadata.map(_.kuvaus) match {
       case Some(kuvaukset: Kielistetty) if toteutusExtras =>
-        kuvaukset.keys.map{lang =>
-          <description language={lang.name}>{kuvaukset(lang)}</description>
+        kuvaukset.keys.map { lang =>
+          <description language={lang.name}>{cleanHtml(kuvaukset(lang))}</description>
         }.toList
       case _ => List()
     }
@@ -138,11 +141,11 @@ class EuropassConversion extends Logging {
     (opetus.map(_.opetusaikaKuvaus).map(_.toList).getOrElse(List()) ++
       opetus.map(_.opetustapaKuvaus).map(_.toList).getOrElse(List()))
         .take(1)  // No way to express language alternatives so we just pick a random one
-        .map{case (lang, desc) =>
+        .map { case (lang, desc) =>
           <scheduleInformation>
-            <noteLiteral language={lang.name}>{desc}</noteLiteral>
+            <noteLiteral language={lang.name}>{cleanHtml(desc)}</noteLiteral>
           </scheduleInformation>
-        }.toList
+        }
   }
 
   def toteutusAsElmXml(toteutus: ToteutusIndexed): Option[Elem] = {
@@ -241,7 +244,7 @@ class EuropassConversion extends Logging {
 
   def kielistettyAsNoteLiterals(content: Kielistetty): Iterable[Elem] =
     content.keys.take(1)  // No way to express language alternatives so we just pick a random one
-      .map{lang => <noteLiteral language={lang.name}>{content(lang)}</noteLiteral>}
+      .map{lang => <noteLiteral language={lang.name}>{cleanHtml(content(lang))}</noteLiteral>}
 
   def tarjoajaAsElmXml(tarjoaja: OppilaitosIndexed): Elem = {
     val nimet = tarjoaja.nimi.getOrElse(Map())
@@ -286,6 +289,10 @@ class EuropassConversion extends Logging {
   def toteutusToTarjoajaDependents(toteutus: ToteutusIndexed): Iterable[Organisaatio] =
     toteutus.tarjoajat
 
+  private def cleanHtml(s: String): String = {
+    val document: org.jsoup.nodes.Document = cleaner.clean(Jsoup.parse(s))
+    document.text
+  }
 }
 
 object EuropassConversion extends EuropassConversion

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassConversion.scala
@@ -14,6 +14,7 @@ import org.jsoup.safety.Safelist
 class EuropassConversion extends Logging {
   implicit val formats = DefaultFormats
 
+  /** @see [[EuropassConversion.cleanHtml]] */
   private val safelist = Safelist.none()
     .addTags("h1", "h2", "h3", "h4", "h5", "h6", "p", "strong", "b", "em", "i", "code", "ul", "ol", "li", "br", "hr", "u", "address", "section", "small", "sub", "sup")
     .addAttributes("li", "value")
@@ -296,7 +297,7 @@ class EuropassConversion extends Logging {
   def cleanHtml(s: String, oid: Option[Oid]): String = {
     val html = Jsoup.parse(s)
 
-    removeLinks(html)
+    convertLinksToText(html)
 
     val htmlString = html.body().html().trim
     if (!Jsoup.isValid(htmlString, safelist)) {
@@ -306,7 +307,7 @@ class EuropassConversion extends Logging {
     Jsoup.clean(htmlString, safelist)
   }
 
-  private def removeLinks(html: Document): Unit = {
+  private def convertLinksToText(html: Document): Unit = {
     val links = html.select("a[href]")
     links.forEach { element =>
       val url = element.attr("href")

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassPublisherApp.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/EuropassPublisherApp.scala
@@ -54,7 +54,7 @@ object EuropassPublisherApp extends Logging {
     logger.info(s"Querying koulutustarjonta from $elasticUrl")
     val fileName = Publisher.koulutustarjontaAsFile()
     logger.info(s"Toteutukset dumped in $fileName; validating")
-    assert(ElmValidation.validateXml(fileName))
+    ElmValidation.validateXml(fileName)
     logger.info(s"XML in $fileName validates against loq.xsd")
     val result = dokumenttipalvelu.putObject(
       s3Key, fileName, "application/xml", new BufferedInputStream(new FileInputStream(fileName))

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
@@ -24,7 +24,7 @@ class Publisher(converter: EuropassConversion) extends Logging {
   def toteutusToFile(oid: String, dest: BufferedWriter) = {
     val Some(toteutusXml: Elem) = converter.toteutusAsElmXml(ElasticClient.getToteutus(oid))
     dest.write(
-      <Courses xmlns="http://data.europa.eu/snb/model/ap/loq-constraints/">
+      <Courses xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/" >
         <learningOpportunityReferences>
           {toteutusXml}
         </learningOpportunityReferences>
@@ -132,7 +132,7 @@ class Publisher(converter: EuropassConversion) extends Logging {
     val toteutusStream = toteutukset(limitToteutukset, toteutusLimit)
     lazy val koulutusStream = koulutusDependentsOfToteutukset(toteutusStream)
     lazy val tarjoajaStream = tarjoajaDependentsOfToteutukset(toteutusStream)
-    dest.write("<Courses xmlns=\"http://data.europa.eu/snb/model/ap/loq-constraints/\">\n")
+    dest.write("<Courses xmlns=\"http://data.europa.eu/snb/model/application-profile/loq-constraints/\">\n")
     toteutuksetToFile(dest, toteutusStream)
     koulutuksetToFile(dest, koulutusStream)
     tuloksetToFile(dest, koulutusStream)

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
@@ -21,7 +21,7 @@ class Publisher(converter: EuropassConversion) extends Logging {
     "europass-publisher.retrieval.toteutus-limit"
   )
 
-  def toteutusToFile(oid: String, dest: BufferedWriter) = {
+  def toteutusToFile(oid: String, dest: BufferedWriter): Unit = {
     val Some(toteutusXml: Elem) = converter.toteutusAsElmXml(ElasticClient.getToteutus(oid))
     dest.write(
       <Courses xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/" >

--- a/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
+++ b/europass-publisher/src/main/scala/fi/oph/kouta/europass/Publisher.scala
@@ -21,18 +21,6 @@ class Publisher(converter: EuropassConversion) extends Logging {
     "europass-publisher.retrieval.toteutus-limit"
   )
 
-  def toteutusToFile(oid: String, dest: BufferedWriter): Unit = {
-    val Some(toteutusXml: Elem) = converter.toteutusAsElmXml(ElasticClient.getToteutus(oid))
-    dest.write(
-      <Courses xmlns="http://data.europa.eu/snb/model/application-profile/loq-constraints/" >
-        <learningOpportunityReferences>
-          {toteutusXml}
-        </learningOpportunityReferences>
-      </Courses>.toString
-    )
-    dest.close()
-  }
-
   def foreachWithLogging(seq: Stream[Elem], kind: String, handle: Elem => Unit) = {
     var writtenCount = 0;
     seq.foreach {item =>

--- a/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
+++ b/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
@@ -64,7 +64,7 @@
   },
   "metadata": {
     "kuvaus": {
-      "en": "A course. <p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine. <a href=\"https: //opintopolku.fi\">Lisätietoja</a></p>"
+      "en": "A course. <p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine. <a href=\"https: //opintopolku.fi\" target=\"_blank\" rel=\"noopener noreferrer\">Lisätietoja</a></p>"
     },
     "hakutermi": "ilmoittautuminen",
     "opintojenLaajuusyksikko": {

--- a/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
+++ b/europass-publisher/src/test/resources/toteutus-ihan-tavanomainen.json
@@ -64,7 +64,7 @@
   },
   "metadata": {
     "kuvaus": {
-      "en": "<p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine.</p>"
+      "en": "A course. <p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine. <a href=\"https: //opintopolku.fi\">Lisätietoja</a></p>"
     },
     "hakutermi": "ilmoittautuminen",
     "opintojenLaajuusyksikko": {

--- a/europass-publisher/src/test/resources/toteutus-with-links.json
+++ b/europass-publisher/src/test/resources/toteutus-with-links.json
@@ -64,7 +64,8 @@
   },
   "metadata": {
     "kuvaus": {
-      "en": "<p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine.</p>"
+      "fi": "<div> <div> <div> <div> <div> <div> <div> <p>Hyvä ruoka ja ravitsemus ovat laadukkaan elämän edellytyksiä.</p> <p>Ravitsemustieteen opinnoista saat perustiedot muun muassa ravintoaineista, elintarvikkeiden koostumuksesta, ihmisen fysiologiasta, erityisruokavalioista sekä ravinnon yhteyksistä terveyteen ja liikuntaan.</p> <p>Tieteenalana ravitsemustiede pohjautuu kemiaan ja fysiologiaan, mutta se kytkeytyy myös moniin sosiaalisiin, taloudellisiin, kulttuurisiin ja psykologisiin ruokaan liittyviin kysymyksiin.</p> <p>Tarkemmat tiedot opintojaksoista ja -kokonaisuuksista, kuten opintojen toteutuksesta, aikatauluista ja suoritustapavaihtoehdoista, löydät <a href=\"https://www.helsinki.fi/fi/hakeminen-ja-opetus/avoin-yliopisto/avoimet-opinnot-koulutusohjelmittain/ihmisen-ravitsemuksen-ja-ruokakayttaytymisen-opinnot/ravitsemustieteen-opinnot\">verkkosivuiltamme (ks. opinto-ohjelmat=kurssisivut).</a></p> </div> </div> </div> </div> </div> </div> </div>",
+      "en": "A course. <p>The aim of the course is to give the students basic idea of the most  usual statistical methods that are used when practicing evidence based  medicine. <a href=\"https://opintopolku.fi/more-information\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>. Also see: <a href=\"https://opintopolku.fi/instructions\" target=\"_blank\" rel=\"noopener noreferrer\">https://opintopolku.fi/instructions</a>.</p>"
     },
     "hakutermi": "ilmoittautuminen",
     "opintojenLaajuusyksikko": {
@@ -183,7 +184,9 @@
           }
         }
       ],
-      "opetusaikaKuvaus": {},
+      "opetusaikaKuvaus": {
+        "en": "See <a href=\"https://opintopolku.fi/opetusaikakuvaus\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>."
+      },
       "opetuskieli": [
         {
           "koodiUri": "oppilaitoksenopetuskieli_4#2",

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -76,13 +76,12 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
   "totally ordinary toteutus" should "have all optional fields" in {
     val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
-    assert(!(toteutusXml \ "description" ).text.contains("<"))
-    assert(!(toteutusXml \ "description" ).text.contains("&lt;"))
-    assert((toteutusXml \ "description" ).text.endsWith(". Lisätietoja"))
+    assert((toteutusXml \ "description" ).text.contains("<p>"))
+    assert((toteutusXml \ "description" ).text.endsWith("<a href=\"https: //opintopolku.fi\">Lisätietoja</a></p>"))
     assert((toteutusXml \ "duration").text == "P0Y0M")
     // from opetustapaKuvaus, since it doesn't have opetusaikaKuvaus
     assert(toteutusXml \ "scheduleInformation" \ "noteLiteral" \@ "language" == "en")
-    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text.startsWith("Online course."))
+    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text.startsWith("<p>Online course."))
   }
 
   "example_toteutus" should "have correct fields" in {

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -1,23 +1,16 @@
 package fi.oph.kouta.europass.test
 
-import scala.io.Source
-import scala.xml._
-import java.io.StringWriter
-import scala.reflect.{ClassTag, classTag}
-
+import fi.oph.kouta.domain.Sv
 import fi.oph.kouta.europass.EuropassConversion
+import fi.oph.kouta.external.domain.indexed.{KoulutusIndexed, OppilaitosIndexed, ToteutusIndexed}
 import fi.oph.kouta.external.util.KoutaJsonFormats
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
-import org.json4s.jackson.Serialization.{read, write}
+import org.json4s.jackson.Serialization.read
+import org.scalatest.Inspectors.forEvery
 import org.scalatra.test.scalatest.ScalatraFlatSpec
 
-import fi.oph.kouta.external.domain.indexed.{
-  KoulutusIndexed,
-  ToteutusIndexed,
-  OppilaitosIndexed
-}
-import fi.oph.kouta.domain.{Kieli, Sv}
+import java.io.StringWriter
+import scala.io.Source
+import scala.xml.{Elem, XML}
 
 object TestConversion extends EuropassConversion
 
@@ -37,6 +30,8 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     read[ToteutusIndexed](resource("toteutus-ihan-tavanomainen.json"))
   lazy val toteutusExactStartTime =
     read[ToteutusIndexed](resource("toteutus-tarkka-alkuaika.json"))
+  lazy val toteutusWithLinks =
+    read[ToteutusIndexed](resource("toteutus-with-links.json"))
 
   lazy val example_koulutus =
     read[KoulutusIndexed](resource("koulutus-example-1.json"))
@@ -77,11 +72,32 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
     assert((toteutusXml \ "description" ).text.contains("<p>"))
-    assert((toteutusXml \ "description" ).text.endsWith(" Lisätietoja</p>"))
     assert((toteutusXml \ "duration").text == "P0Y0M")
     // from opetustapaKuvaus, since it doesn't have opetusaikaKuvaus
     assert(toteutusXml \ "scheduleInformation" \ "noteLiteral" \@ "language" == "en")
     assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text.startsWith("<p>Online course."))
+  }
+
+  "toteutus with links" should "have changed links to text" in {
+    val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusWithLinks)
+    assert(!(toteutusXml \ "description" ).text.contains("<a"))
+    assert((toteutusXml \ "description" ).text.contains("More information (https://opintopolku.fi/more-information)"))
+    assert(!(toteutusXml \ "scheduleInformation" \ "noteLiteral").text.contains("<a"))
+    assert(!(toteutusXml \ "scheduleInformation" \ "noteLiteral").text.eq("See here (https://opintopolku.fi/opetusaikakuvaus)"))
+  }
+
+  it should "not repeat the url if the link description is the same as the address" in {
+    val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusWithLinks)
+    val kuvausEn = (toteutusXml \ "description").filter(d => (d \@ "language") == "en").map(_.text).head
+    assert(kuvausEn.endsWith("Also see: https://opintopolku.fi/instructions.</p>"))
+  }
+
+  it should "remove <div>s, but leave the content of those divs" in {
+    val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusWithLinks)
+    val kuvausFi = (toteutusXml \ "description").filter(d => (d \@ "language") == "fi").map(_.text).head
+    assert(!kuvausFi.contains("<div>"))
+    assert(!kuvausFi.contains("</div>"))
+    assert(kuvausFi.contains("<p>Hyvä ruoka "))
   }
 
   "example_toteutus" should "have correct fields" in {
@@ -236,4 +252,84 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     assert((tulosXml(0) \ "title")(2) \@ "language" == "sv")
   }
 
+  "cleanHtml" should "allow value attributes in list items" in {
+    val string =
+      """<ul>
+        |<li value="1">selkeän ja uskottavan liiketoimintasuunnitelman&nbsp;</li>
+        |<li value="2">siihen liittyvät talouslaskelmat&nbsp;</li>
+        |<li value="3">yrityksen perustamisasiakirjat&nbsp;</li>
+        |<li value="4">toimialasi vaatimatlisäasiakirjat ja lakisääteiset ilmoitukset&nbsp;</li>
+        |</ul>""".stripMargin
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response.contains("""<li value="1">"""))
+    assert(response.contains("""<li value="2">"""))
+    assert(response.contains("""<li value="3">"""))
+    assert(response.contains("""<li value="4">"""))
+  }
+
+  it should "remove link elements with empty urls" in {
+    val string = """<a href="" rel="noopener noreferrer" target="_blank">See detailed instruction time and location in the Uniarts study guide.</a>"""
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "See detailed instruction time and location in the Uniarts study guide.")
+  }
+
+  it should "handle tel: links in a sane way" in {
+    val string =
+      """<a href="tel:+358 41 123 4567" rel="noopener noreferrer" target="_blank">+358 411 234567</a>
+        |<a href="tel:+358 44 765 4321" rel="noopener noreferrer" target="_blank">+358 44 765 4321&nbsp;</a>"""
+        .stripMargin
+    val response = EuropassConversion.cleanHtml(string, None).replace("\n", " ")
+    assert(response == "+358 41 123 4567 +358 44 765 4321")
+
+  }
+
+  it should "handle mailto: links in a sane way" in {
+    val string =  "<p>Etunimi Sukunimi,&nbsp;<a href=\"mailto:etunimi.sukunimi@test.fi\" target=\"_blank\" rel=\"noopener noreferrer\">etunimi.sukunimi@test.fi </a>, p. 050 123 4567&nbsp;</p>"
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "<p>Etunimi Sukunimi,&nbsp;etunimi.sukunimi@test.fi, p. 050 123 4567&nbsp;</p>")
+  }
+
+  it should "remove links within the same page" in {
+    val string = "<p><a href=\"#_msocom_1\" target=\"_blank\" rel=\"noopener noreferrer\">[V1]</a></p>"
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "<p>[V1]</p>")
+  }
+
+  it should "remove links to about:blank" in {
+    val string = """<li value="2"><a href="about:blank" target="_blank" rel="noopener noreferrer">Porin lukio</a></li>"""
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "<li value=\"2\">Porin lukio</li>")
+  }
+
+  it should "allow style for p elements" in {
+    val string = """<p style="text-align: left;">Optometristin opintojen&nbsp;ja potilastyön taustalla on tutkittuun näyttöön perustuvaa toiminta.</p>"""
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == string)
+  }
+
+  it should "allow style for li elements" in {
+    val string = """<li value="4" style="text-align: start;">ottamaan vastuuta ja kokeilemaan omia vahvuuksiasi käytännössä</li>"""
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response.startsWith("""<li value="4" style="text-align: start;">ottamaan vastuuta ja kokeilemaan omia vahvuuksiasi käytännössä</li>"""))
+  }
+
+  it should "allow style for h* elements" in {
+    forEvery(1 to 6) { i =>
+      val string = s"""<h$i style="text-align: start;">&nbsp;<strong>Oma tie – Koulutus sopii erityisesti sinulle, joka</strong></h$i>"""
+      val response = EuropassConversion.cleanHtml(string, None)
+      assert(response == s"""<h$i style="text-align: start;">&nbsp;<strong>Oma tie – Koulutus sopii erityisesti sinulle, joka</strong></h$i>""")
+    }
+  }
+
+  it should "allow start attribute for ol elements" in {
+    val string = "<ol start=\"2\"> <li value=\"2\"><em>CV/Ansioluettelo</em></li>\n</ol>"
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "<ol start=\"2\">\n <li value=\"2\"><em>CV/Ansioluettelo</em></li>\n</ol>")
+  }
+
+  it should "remove <s> elements, but leave their content" in {
+    val string = "Kaikki harjoittelut tehdään Hollolassa, Asikkalassa, Padasjoeella, Orimattilassa tai Heinolassa <s>alueella</s>"
+    val response = EuropassConversion.cleanHtml(string, None)
+    assert(response == "Kaikki harjoittelut tehdään Hollolassa, Asikkalassa, Padasjoeella, Orimattilassa tai Heinolassa alueella")
+  }
 }

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -77,7 +77,7 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
     val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
     assert((toteutusXml \ "description" ).text.contains("<p>"))
-    assert((toteutusXml \ "description" ).text.endsWith("<a href=\"https: //opintopolku.fi\">Lisätietoja</a></p>"))
+    assert((toteutusXml \ "description" ).text.endsWith(" Lisätietoja</p>"))
     assert((toteutusXml \ "duration").text == "P0Y0M")
     // from opetustapaKuvaus, since it doesn't have opetusaikaKuvaus
     assert(toteutusXml \ "scheduleInformation" \ "noteLiteral" \@ "language" == "en")

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/ConversionSpec.scala
@@ -76,11 +76,13 @@ class ConversionSpec extends ScalatraFlatSpec with KoutaJsonFormats {
   "totally ordinary toteutus" should "have all optional fields" in {
     val Some(toteutusXml: Elem) = TestConversion.toteutusAsElmXml(toteutusTotallyOrdinary)
     assert(toteutusXml \ "description" \@ "language" == "en")
+    assert(!(toteutusXml \ "description" ).text.contains("<"))
+    assert(!(toteutusXml \ "description" ).text.contains("&lt;"))
+    assert((toteutusXml \ "description" ).text.endsWith(". Lisätietoja"))
     assert((toteutusXml \ "duration").text == "P0Y0M")
     // from opetustapaKuvaus, since it doesn't have opetusaikaKuvaus
     assert(toteutusXml \ "scheduleInformation" \ "noteLiteral" \@ "language" == "en")
-    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text
-      .startsWith("<p>Online course."))
+    assert((toteutusXml \ "scheduleInformation" \ "noteLiteral").text.startsWith("Online course."))
   }
 
   "example_toteutus" should "have correct fields" in {

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
@@ -19,21 +19,6 @@ class PublisherSpec extends ScalatraFlatSpec with ElasticFixture with KoutaJsonF
 
   def resource(filename: String) = Source.fromResource(filename).bufferedReader
 
-  "toteutusToFile" should "create correct toteutusXml from ElasticSearch" in {
-    val writer = new StringWriter()
-    val bwriter = new BufferedWriter(writer)
-    TestPublisher.toteutusToFile("1.2.246.562.17.00000000000000000001", bwriter)
-    bwriter.close()
-    assert(writer.toString.contains("<contentUrl>https://opintopolku.fi/konfo/sv/toteutus/1.2.246.562.17.00000000000000000001</contentUrl>"))
-    assert(writer.toString.contains("<providedBy idref=\"https://rdf.oph.fi/organisaatio/1.2.246.562.10.594252633210\"/>"))
-
-    // Want to have the test XML as a file?  Here you go:
-    // val w = new BufferedWriter(new FileWriter("test.txt"))
-    // w.write(writer.toString)
-    // w.close()
-
-  }
-
   "toteutuksetToFile" should "have toteutukset" in {
     val writer = new StringWriter()
     val bwriter = new BufferedWriter(writer)

--- a/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
+++ b/europass-publisher/src/test/scala/fi/oph/kouta/europass/test/PublisherSpec.scala
@@ -101,7 +101,7 @@ class PublisherSpec extends ScalatraFlatSpec with ElasticFixture with KoutaJsonF
     assert(fileName.contains("europass-export"))
     val content = Source.fromFile(fileName).mkString
     assert(content.contains("<title language=\"sv\">nimi sv</title>"))
-    assert(ElmValidation.validateXml(fileName))
+    ElmValidation.validateXml(fileName)
   }
 
   "koulutusDependentsOfToteutukset" should "have all koulutukset" in {
@@ -113,4 +113,3 @@ class PublisherSpec extends ScalatraFlatSpec with ElasticFixture with KoutaJsonF
   }
 
 }
-


### PR DESCRIPTION
Validoinnissa käytettyjä XSD-skeemoja ei näytä olevan päivitetty uusimpaan versioon. Lähetin Europassille kysymyksen, onko sitä saatavilla. Toistaiseksi päivitin XSD-skeemat vastaamaan uusia osoitteita, jotta validointi menee läpi. Pitänee palata tähän riippuen, mitä vastaavat, jos vastaavat.